### PR TITLE
Update Feed.GoogleShopping to version 5.00.1

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -94,7 +94,7 @@ jobs:
             { "SystemName": "Widgets.ImagePuzzle", "Version": "1.00" },
             { "SystemName": "Widgets.ShoppableBanner", "Version": "1.00" },
             { "SystemName": "Misc.MegaMenu", "Version": "1.00"},
-            { "SystemName": "Feed.GoogleShopping", "Version": "5.00.0"},
+            { "SystemName": "Feed.GoogleShopping", "Version": "5.00.1"},
             { "SystemName": "Widgets.SeoEnhancements","Version": "1.00"}
           ],
           "PluginNamesToUninstall": [],


### PR DESCRIPTION
Update Feed.GoogleShopping to version 5.00.1

Updated the `Feed.GoogleShopping` plugin version from `5.00.0` to `5.00.1` in the `deploy-production.yml` file. This likely includes minor updates such as bug fixes, performance improvements, or small feature enhancements.