### PR TITLE
Add Azure Blob Storage support to Google Shopping plugin

### DIFF
--- a/src/Plugins/Nop.Plugin.Feed.GoogleShopping/Controllers/FeedGoogleShoppingController.cs
+++ b/src/Plugins/Nop.Plugin.Feed.GoogleShopping/Controllers/FeedGoogleShoppingController.cs
@@ -107,6 +107,13 @@ public class FeedGoogleShoppingController : BasePluginController
         model.PassShippingInfoDimensions = googleShoppingSettings.PassShippingInfoDimensions;
         model.PricesConsiderPromotions = googleShoppingSettings.PricesConsiderPromotions;
 
+        // Azure Blob Storage settings
+        model.UseAzureBlobStorage = googleShoppingSettings.UseAzureBlobStorage;
+        model.AzureBlobConnectionString = googleShoppingSettings.AzureBlobConnectionString;
+        model.AzureBlobContainerName = googleShoppingSettings.AzureBlobContainerName;
+        model.AzureBlobEndPoint = googleShoppingSettings.AzureBlobEndPoint;
+        model.AzureBlobAppendContainerName = googleShoppingSettings.AzureBlobAppendContainerName;
+
         //currencies
         model.CurrencyId = googleShoppingSettings.CurrencyId;
         foreach (var c in await _currencyService.GetAllCurrenciesAsync())
@@ -160,13 +167,26 @@ public class FeedGoogleShoppingController : BasePluginController
         //file paths
         foreach (var store in await _storeService.GetAllStoresAsync())
         {
-            var localFilePath = _nopFileProvider.Combine(_webHostEnvironment.WebRootPath, "files", "exportimport", store.Id + "-" + googleShoppingSettings.StaticFileName);
-            if (_nopFileProvider.FileExists(localFilePath))
+            if (googleShoppingSettings.UseAzureBlobStorage)
+            {
+                // Always serve the dynamic endpoint URL that points Google to the correct location
+                var dynamicUrl = $"{_webHelper.GetStoreLocation(false)}googleshopping/feed?storeId={store.Id}";
                 model.GeneratedFiles.Add(new GeneratedFileModel
                 {
                     StoreName = store.Name,
-                    FileUrl = $"{_webHelper.GetStoreLocation(false)}files/exportimport/{store.Id}-{googleShoppingSettings.StaticFileName}"
+                    FileUrl = dynamicUrl
                 });
+            }
+            else
+            {
+                var localFilePath = _nopFileProvider.Combine(_webHostEnvironment.WebRootPath, "files", "exportimport", store.Id + "-" + googleShoppingSettings.StaticFileName);
+                if (_nopFileProvider.FileExists(localFilePath))
+                    model.GeneratedFiles.Add(new GeneratedFileModel
+                    {
+                        StoreName = store.Name,
+                        FileUrl = $"{_webHelper.GetStoreLocation(false)}files/exportimport/{store.Id}-{googleShoppingSettings.StaticFileName}"
+                    });
+            }
         }
 
         model.ActiveStoreScopeConfiguration = storeScope;
@@ -178,6 +198,13 @@ public class FeedGoogleShoppingController : BasePluginController
             model.PassShippingInfoWeight_OverrideForStore = await _settingService.SettingExistsAsync(googleShoppingSettings, x => x.PassShippingInfoWeight, storeScope);
             model.PricesConsiderPromotions_OverrideForStore = await _settingService.SettingExistsAsync(googleShoppingSettings, x => x.PricesConsiderPromotions, storeScope);
             model.ProductPictureSize_OverrideForStore = await _settingService.SettingExistsAsync(googleShoppingSettings, x => x.ProductPictureSize, storeScope);
+            
+            // Azure Blob overrides
+            model.UseAzureBlobStorage_OverrideForStore = await _settingService.SettingExistsAsync(googleShoppingSettings, x => x.UseAzureBlobStorage, storeScope);
+            model.AzureBlobConnectionString_OverrideForStore = await _settingService.SettingExistsAsync(googleShoppingSettings, x => x.AzureBlobConnectionString, storeScope);
+            model.AzureBlobContainerName_OverrideForStore = await _settingService.SettingExistsAsync(googleShoppingSettings, x => x.AzureBlobContainerName, storeScope);
+            model.AzureBlobEndPoint_OverrideForStore = await _settingService.SettingExistsAsync(googleShoppingSettings, x => x.AzureBlobEndPoint, storeScope);
+            model.AzureBlobAppendContainerName_OverrideForStore = await _settingService.SettingExistsAsync(googleShoppingSettings, x => x.AzureBlobAppendContainerName, storeScope);
         }
     }
 
@@ -221,6 +248,13 @@ public class FeedGoogleShoppingController : BasePluginController
         googleShoppingSettings.CurrencyId = model.CurrencyId;
         googleShoppingSettings.DefaultGoogleCategory = model.DefaultGoogleCategory;
 
+        // Azure Blob Storage settings
+        googleShoppingSettings.UseAzureBlobStorage = model.UseAzureBlobStorage;
+        googleShoppingSettings.AzureBlobConnectionString = model.AzureBlobConnectionString;
+        googleShoppingSettings.AzureBlobContainerName = model.AzureBlobContainerName;
+        googleShoppingSettings.AzureBlobEndPoint = model.AzureBlobEndPoint;
+        googleShoppingSettings.AzureBlobAppendContainerName = model.AzureBlobAppendContainerName;
+
         //_settingService.SaveSetting(_googleShoppingSettings);
 
         /* We do not clear cache after each setting update.
@@ -232,6 +266,13 @@ public class FeedGoogleShoppingController : BasePluginController
         await _settingService.SaveSettingOverridablePerStoreAsync(googleShoppingSettings, x => x.PassShippingInfoWeight, model.PassShippingInfoWeight_OverrideForStore, storeScope, false);
         await _settingService.SaveSettingOverridablePerStoreAsync(googleShoppingSettings, x => x.PricesConsiderPromotions, model.PricesConsiderPromotions_OverrideForStore, storeScope, false);
         await _settingService.SaveSettingOverridablePerStoreAsync(googleShoppingSettings, x => x.ProductPictureSize, model.ProductPictureSize_OverrideForStore, storeScope, false);
+
+        // Azure Blob Storage overrides
+        await _settingService.SaveSettingOverridablePerStoreAsync(googleShoppingSettings, x => x.UseAzureBlobStorage, model.UseAzureBlobStorage_OverrideForStore, storeScope, false);
+        await _settingService.SaveSettingOverridablePerStoreAsync(googleShoppingSettings, x => x.AzureBlobConnectionString, model.AzureBlobConnectionString_OverrideForStore, storeScope, false);
+        await _settingService.SaveSettingOverridablePerStoreAsync(googleShoppingSettings, x => x.AzureBlobContainerName, model.AzureBlobContainerName_OverrideForStore, storeScope, false);
+        await _settingService.SaveSettingOverridablePerStoreAsync(googleShoppingSettings, x => x.AzureBlobEndPoint, model.AzureBlobEndPoint_OverrideForStore, storeScope, false);
+        await _settingService.SaveSettingOverridablePerStoreAsync(googleShoppingSettings, x => x.AzureBlobAppendContainerName, model.AzureBlobAppendContainerName_OverrideForStore, storeScope, false);
 
         //now clear settings cache
         await _settingService.ClearCacheAsync();

--- a/src/Plugins/Nop.Plugin.Feed.GoogleShopping/Controllers/GoogleShoppingFeedController.cs
+++ b/src/Plugins/Nop.Plugin.Feed.GoogleShopping/Controllers/GoogleShoppingFeedController.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Azure.Storage.Blobs;
+using Nop.Core;
+using Nop.Core.Domain.Stores;
+using Nop.Core.Infrastructure;
+using Nop.Plugin.Feed.GoogleShopping.Services;
+using Nop.Services.Configuration;
+using Nop.Services.Plugins;
+using Nop.Services.Stores;
+
+namespace Nop.Plugin.Feed.GoogleShopping.Controllers;
+
+public class GoogleShoppingFeedController : Controller
+{
+    private readonly ISettingService _settingService;
+    private readonly IStoreContext _storeContext;
+    private readonly IStoreService _storeService;
+    private readonly IPluginService _pluginService;
+    private readonly INopFileProvider _nopFileProvider;
+    private readonly IWebHostEnvironment _webHostEnvironment;
+
+    public GoogleShoppingFeedController(
+        ISettingService settingService,
+        IStoreContext storeContext,
+        IStoreService storeService,
+        IPluginService pluginService,
+        INopFileProvider nopFileProvider,
+        IWebHostEnvironment webHostEnvironment)
+    {
+        _settingService = settingService;
+        _storeContext = storeContext;
+        _storeService = storeService;
+        _pluginService = pluginService;
+        _nopFileProvider = nopFileProvider;
+        _webHostEnvironment = webHostEnvironment;
+    }
+
+    [HttpGet("googleshopping/feed")]
+    public async Task<IActionResult> GetFeed(int storeId = 0)
+    {
+        // Resolve store
+        Store store = null;
+        if (storeId > 0)
+        {
+            store = await _storeService.GetStoreByIdAsync(storeId);
+        }
+        if (store == null)
+        {
+            store = await _storeContext.GetCurrentStoreAsync();
+        }
+        if (store == null)
+        {
+            return NotFound("Store not found.");
+        }
+
+        // Load settings for the store
+        var googleShoppingSettings = await _settingService.LoadSettingAsync<GoogleShoppingSettings>(store.Id);
+
+        if (googleShoppingSettings.UseAzureBlobStorage)
+        {
+            if (string.IsNullOrEmpty(googleShoppingSettings.AzureBlobConnectionString) ||
+                string.IsNullOrEmpty(googleShoppingSettings.AzureBlobContainerName))
+            {
+                return BadRequest("Azure Blob Storage is not fully configured.");
+            }
+
+            var fileName = $"{store.Id}-{googleShoppingSettings.StaticFileName}";
+            var blobServiceClient = new BlobServiceClient(googleShoppingSettings.AzureBlobConnectionString);
+            var containerClient = blobServiceClient.GetBlobContainerClient(googleShoppingSettings.AzureBlobContainerName);
+            var blobClient = containerClient.GetBlobClient(fileName);
+
+            return Redirect(blobClient.Uri.ToString());
+        }
+        else
+        {
+            // Local file serving fallback
+            var localFilePath = _nopFileProvider.Combine(_webHostEnvironment.WebRootPath, "files", "exportimport", store.Id + "-" + googleShoppingSettings.StaticFileName);
+            if (!_nopFileProvider.FileExists(localFilePath))
+            {
+                return NotFound("Feed file not found. Please generate the feed in the plugin administration first.");
+            }
+
+            var fileBytes = await _nopFileProvider.ReadAllBytesAsync(localFilePath);
+            return File(fileBytes, "application/xml", store.Id + "-" + googleShoppingSettings.StaticFileName);
+        }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Feed.GoogleShopping/GoogleShoppingService.cs
+++ b/src/Plugins/Nop.Plugin.Feed.GoogleShopping/GoogleShoppingService.cs
@@ -16,10 +16,12 @@ using Nop.Services.Helpers;
 using Nop.Services.Localization;
 using Nop.Services.Media;
 using Nop.Services.Plugins;
+using Nop.Services.ScheduleTasks;
 using Nop.Services.Seo;
 using Nop.Services.Tax;
 using Nop.Web.Framework.Mvc.Routing;
 using System.Globalization;
+using System.IO;
 using System.Net;
 using System.Text;
 using System.Xml;
@@ -52,6 +54,7 @@ public class GoogleShoppingService : BasePlugin, IMiscPlugin
     private readonly IWorkContext _workContext;
     private readonly MeasureSettings _measureSettings;
     private readonly INopUrlHelper _nopUrlHelper;
+    private readonly IScheduleTaskService _scheduleTaskService;
 
     #endregion
 
@@ -79,7 +82,8 @@ public class GoogleShoppingService : BasePlugin, IMiscPlugin
         IWebHostEnvironment webHostEnvironment,
         IWorkContext workContext,
         MeasureSettings measureSettings,
-        INopUrlHelper nopUrlHelper
+        INopUrlHelper nopUrlHelper,
+        IScheduleTaskService scheduleTaskService
         )
     {
         _categoryService = categoryService;
@@ -103,6 +107,7 @@ public class GoogleShoppingService : BasePlugin, IMiscPlugin
         _webHelper = webHelper;
         _webHostEnvironment = webHostEnvironment;
         _workContext = workContext;
+        _scheduleTaskService = scheduleTaskService;
         _nopUrlHelper = nopUrlHelper;
     }
 
@@ -565,7 +570,7 @@ public class GoogleShoppingService : BasePlugin, IMiscPlugin
         writer.WriteEndDocument();
     }
 
-    // <summary>
+    /// <summary>
     /// Install the plugin
     /// </summary>
     /// <returns>A task that represents the asynchronous operation</returns>
@@ -579,7 +584,12 @@ public class GoogleShoppingService : BasePlugin, IMiscPlugin
             PassShippingInfoWeight = false,
             PassShippingInfoDimensions = false,
             StaticFileName = $"googleshopping_{CommonHelper.GenerateRandomDigitCode(10)}.xml",
-            ExpirationNumberOfDays = 28
+            ExpirationNumberOfDays = 28,
+            UseAzureBlobStorage = false,
+            AzureBlobConnectionString = string.Empty,
+            AzureBlobContainerName = string.Empty,
+            AzureBlobEndPoint = string.Empty,
+            AzureBlobAppendContainerName = true
         };
         await _settingService.SaveSettingAsync(settings);
 
@@ -624,8 +634,32 @@ public class GoogleShoppingService : BasePlugin, IMiscPlugin
             ["Plugins.Feed.GoogleShopping.Products.UseShortDescription.Hint"] = "Check to use the product's short description instead of the full description in the feed.",
             ["Plugins.Feed.GoogleShopping.SuccessResult"] = "Google Shopping feed has been successfully generated.",
             ["Plugins.Feed.GoogleShopping.StaticFilePath"] = "Generated file path (static)",
-            ["Plugins.Feed.GoogleShopping.StaticFilePath.Hint"] = "A file path of the generated file. It's static for your store and can be shared with the Google Shopping service."
+            ["Plugins.Feed.GoogleShopping.StaticFilePath.Hint"] = "A file path of the generated file. It's static for your store and can be shared with the Google Shopping service.",
+            
+            // Azure Blob resources
+            ["Plugins.Feed.GoogleShopping.UseAzureBlobStorage"] = "Use Azure Blob Storage",
+            ["Plugins.Feed.GoogleShopping.UseAzureBlobStorage.Hint"] = "Check if you want to store the generated Google Shopping feed XML file in Azure Blob Storage.",
+            ["Plugins.Feed.GoogleShopping.AzureBlobConnectionString"] = "Azure Connection String",
+            ["Plugins.Feed.GoogleShopping.AzureBlobConnectionString.Hint"] = "Specify the connection string for Azure Blob Storage.",
+            ["Plugins.Feed.GoogleShopping.AzureBlobContainerName"] = "Azure Container Name",
+            ["Plugins.Feed.GoogleShopping.AzureBlobContainerName.Hint"] = "Specify the container name for Azure Blob Storage.",
+            ["Plugins.Feed.GoogleShopping.AzureBlobEndPoint"] = "Azure Endpoint URL",
+            ["Plugins.Feed.GoogleShopping.AzureBlobEndPoint.Hint"] = "Specify the custom endpoint/CDN URL for Azure Blob Storage (optional).",
+            ["Plugins.Feed.GoogleShopping.AzureBlobAppendContainerName"] = "Append Container Name to URL",
+            ["Plugins.Feed.GoogleShopping.AzureBlobAppendContainerName.Hint"] = "Check if you want the container name to be appended to the custom endpoint URL."
         });
+
+        //register scheduled task
+        if (await _scheduleTaskService.GetTaskByTypeAsync("Nop.Plugin.Feed.GoogleShopping.Services.GoogleShoppingFeedGenerateTask, Nop.Plugin.Feed.GoogleShopping") is null)
+        {
+            await _scheduleTaskService.InsertTaskAsync(new Nop.Core.Domain.ScheduleTasks.ScheduleTask
+            {
+                Name = "Google Shopping Feed Generation",
+                Type = "Nop.Plugin.Feed.GoogleShopping.Services.GoogleShoppingFeedGenerateTask, Nop.Plugin.Feed.GoogleShopping",
+                Seconds = 86400,
+                Enabled = true
+            });
+        }
 
         await base.InstallAsync();
     }
@@ -642,6 +676,11 @@ public class GoogleShoppingService : BasePlugin, IMiscPlugin
         //locales
         await _localizationService.DeleteLocaleResourcesAsync("Plugins.Feed.GoogleShopping");
 
+        //delete scheduled task
+        var scheduleTask = await _scheduleTaskService.GetTaskByTypeAsync("Nop.Plugin.Feed.GoogleShopping.Services.GoogleShoppingFeedGenerateTask, Nop.Plugin.Feed.GoogleShopping");
+        if (scheduleTask is not null)
+            await _scheduleTaskService.DeleteTaskAsync(scheduleTask);
+
         await base.UninstallAsync();
     }
 
@@ -654,9 +693,37 @@ public class GoogleShoppingService : BasePlugin, IMiscPlugin
     {
         ArgumentNullException.ThrowIfNull(store);
 
-        var filePath = _nopFileProvider.Combine(_webHostEnvironment.WebRootPath, "files", "exportimport", store.Id + "-" + _googleShoppingSettings.StaticFileName);
-        using var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
-        await GenerateFeedAsync(fs, store);
+        var googleShoppingSettings = await _settingService.LoadSettingAsync<GoogleShoppingSettings>(store.Id);
+
+        if (googleShoppingSettings.UseAzureBlobStorage)
+        {
+            if (string.IsNullOrEmpty(googleShoppingSettings.AzureBlobConnectionString) ||
+                string.IsNullOrEmpty(googleShoppingSettings.AzureBlobContainerName))
+            {
+                throw new Exception("Azure Blob Storage is not fully configured for Google Shopping.");
+            }
+
+            var fileName = $"{store.Id}-{googleShoppingSettings.StaticFileName}";
+            var blobServiceClient = new Azure.Storage.Blobs.BlobServiceClient(googleShoppingSettings.AzureBlobConnectionString);
+            var containerClient = blobServiceClient.GetBlobContainerClient(googleShoppingSettings.AzureBlobContainerName);
+
+            // Create container if it doesn't exist
+            await containerClient.CreateIfNotExistsAsync(Azure.Storage.Blobs.Models.PublicAccessType.Blob);
+
+            var blobClient = containerClient.GetBlobClient(fileName);
+
+            using var ms = new MemoryStream();
+            await GenerateFeedAsync(ms, store);
+            ms.Position = 0;
+
+            await blobClient.UploadAsync(ms, overwrite: true);
+        }
+        else
+        {
+            var filePath = _nopFileProvider.Combine(_webHostEnvironment.WebRootPath, "files", "exportimport", store.Id + "-" + googleShoppingSettings.StaticFileName);
+            using var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
+            await GenerateFeedAsync(fs, store);
+        }
     }
 
     #endregion

--- a/src/Plugins/Nop.Plugin.Feed.GoogleShopping/GoogleShoppingSettings.cs
+++ b/src/Plugins/Nop.Plugin.Feed.GoogleShopping/GoogleShoppingSettings.cs
@@ -1,4 +1,4 @@
-﻿using Nop.Core.Configuration;
+using Nop.Core.Configuration;
 
 namespace Nop.Plugin.Feed.GoogleShopping;
 
@@ -43,4 +43,29 @@ public class GoogleShoppingSettings : ISettings
     /// Number of days for expiration date
     /// </summary>
     public int ExpirationNumberOfDays { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether we should use Azure Blob Storage for storing the feed
+    /// </summary>
+    public bool UseAzureBlobStorage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Azure Blob Storage connection string
+    /// </summary>
+    public string AzureBlobConnectionString { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Azure Blob Storage container name
+    /// </summary>
+    public string AzureBlobContainerName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Azure Blob Storage endpoint
+    /// </summary>
+    public string AzureBlobEndPoint { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the container name should be appended to the endpoint
+    /// </summary>
+    public bool AzureBlobAppendContainerName { get; set; }
 }

--- a/src/Plugins/Nop.Plugin.Feed.GoogleShopping/Models/FeedGoogleShoppingModel.cs
+++ b/src/Plugins/Nop.Plugin.Feed.GoogleShopping/Models/FeedGoogleShoppingModel.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Nop.Web.Framework.Mvc.ModelBinding;
 
 namespace Nop.Plugin.Feed.GoogleShopping.Models;
@@ -40,6 +40,26 @@ public record FeedGoogleShoppingModel
     [NopResourceDisplayName("Plugins.Feed.GoogleShopping.PricesConsiderPromotions")]
     public bool PricesConsiderPromotions { get; set; }
     public bool PricesConsiderPromotions_OverrideForStore { get; set; }
+
+    [NopResourceDisplayName("Plugins.Feed.GoogleShopping.UseAzureBlobStorage")]
+    public bool UseAzureBlobStorage { get; set; }
+    public bool UseAzureBlobStorage_OverrideForStore { get; set; }
+
+    [NopResourceDisplayName("Plugins.Feed.GoogleShopping.AzureBlobConnectionString")]
+    public string AzureBlobConnectionString { get; set; } = string.Empty;
+    public bool AzureBlobConnectionString_OverrideForStore { get; set; }
+
+    [NopResourceDisplayName("Plugins.Feed.GoogleShopping.AzureBlobContainerName")]
+    public string AzureBlobContainerName { get; set; } = string.Empty;
+    public bool AzureBlobContainerName_OverrideForStore { get; set; }
+
+    [NopResourceDisplayName("Plugins.Feed.GoogleShopping.AzureBlobEndPoint")]
+    public string AzureBlobEndPoint { get; set; } = string.Empty;
+    public bool AzureBlobEndPoint_OverrideForStore { get; set; }
+
+    [NopResourceDisplayName("Plugins.Feed.GoogleShopping.AzureBlobAppendContainerName")]
+    public bool AzureBlobAppendContainerName { get; set; }
+    public bool AzureBlobAppendContainerName_OverrideForStore { get; set; }
 
     [NopResourceDisplayName("Plugins.Feed.GoogleShopping.StaticFilePath")]
     public IList<GeneratedFileModel> GeneratedFiles { get; set; }

--- a/src/Plugins/Nop.Plugin.Feed.GoogleShopping/Services/GoogleShoppingFeedGenerateTask.cs
+++ b/src/Plugins/Nop.Plugin.Feed.GoogleShopping/Services/GoogleShoppingFeedGenerateTask.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading.Tasks;
+using Nop.Services.Plugins;
+using Nop.Services.ScheduleTasks;
+using Nop.Services.Stores;
+
+namespace Nop.Plugin.Feed.GoogleShopping.Services;
+
+/// <summary>
+/// Represents a schedule task to generate Google Shopping feeds
+/// </summary>
+public class GoogleShoppingFeedGenerateTask : IScheduleTask
+{
+    private readonly IPluginService _pluginService;
+    private readonly IStoreService _storeService;
+
+    public GoogleShoppingFeedGenerateTask(
+        IPluginService pluginService,
+        IStoreService storeService)
+    {
+        _pluginService = pluginService;
+        _storeService = storeService;
+    }
+
+    /// <summary>
+    /// Execute task
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    public async Task ExecuteAsync()
+    {
+        var pluginDescriptor = await _pluginService.GetPluginDescriptorBySystemNameAsync<IPlugin>("Feed.GoogleShopping");
+        if (pluginDescriptor == null || !pluginDescriptor.Installed || pluginDescriptor.Instance<IPlugin>() is not GoogleShoppingService plugin)
+        {
+            return;
+        }
+
+        var stores = await _storeService.GetAllStoresAsync();
+        foreach (var store in stores)
+        {
+            try
+            {
+                await plugin.GenerateStaticFileAsync(store);
+            }
+            catch (Exception)
+            {
+                // Ignore exceptions on a per-store basis to prevent blocking other stores
+            }
+        }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Feed.GoogleShopping/Views/_Configure.General.cshtml
+++ b/src/Plugins/Nop.Plugin.Feed.GoogleShopping/Views/_Configure.General.cshtml
@@ -1,4 +1,4 @@
-﻿@model FeedGoogleShoppingModel
+@model FeedGoogleShoppingModel
 
 <div class="card-body">
     @await Component.InvokeAsync(typeof(StoreScopeConfigurationViewComponent))
@@ -65,6 +65,63 @@
                     <span asp-validation-for="DefaultGoogleCategory"></span>
                 </div>
             </div>
+            
+            <hr />
+            <h4>Azure Blob Storage Settings</h4>
+            <p class="text-muted">Configure Azure Blob Storage to store the Google Shopping feed XML file persistently across site updates.</p>
+
+            <div class="form-group row">
+                <div class="col-md-3">
+                    <nop-override-store-checkbox asp-for="UseAzureBlobStorage_OverrideForStore" asp-input="UseAzureBlobStorage" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                    <nop-label asp-for="UseAzureBlobStorage" />
+                </div>
+                <div class="col-md-9">
+                    <nop-editor asp-for="UseAzureBlobStorage" />
+                    <span asp-validation-for="UseAzureBlobStorage"></span>
+                </div>
+            </div>
+            <div class="form-group row">
+                <div class="col-md-3">
+                    <nop-override-store-checkbox asp-for="AzureBlobConnectionString_OverrideForStore" asp-input="AzureBlobConnectionString" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                    <nop-label asp-for="AzureBlobConnectionString" />
+                </div>
+                <div class="col-md-9">
+                    <nop-editor asp-for="AzureBlobConnectionString" />
+                    <span asp-validation-for="AzureBlobConnectionString"></span>
+                </div>
+            </div>
+            <div class="form-group row">
+                <div class="col-md-3">
+                    <nop-override-store-checkbox asp-for="AzureBlobContainerName_OverrideForStore" asp-input="AzureBlobContainerName" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                    <nop-label asp-for="AzureBlobContainerName" />
+                </div>
+                <div class="col-md-9">
+                    <nop-editor asp-for="AzureBlobContainerName" />
+                    <span asp-validation-for="AzureBlobContainerName"></span>
+                </div>
+            </div>
+            <div class="form-group row">
+                <div class="col-md-3">
+                    <nop-override-store-checkbox asp-for="AzureBlobEndPoint_OverrideForStore" asp-input="AzureBlobEndPoint" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                    <nop-label asp-for="AzureBlobEndPoint" />
+                </div>
+                <div class="col-md-9">
+                    <nop-editor asp-for="AzureBlobEndPoint" />
+                    <span asp-validation-for="AzureBlobEndPoint"></span>
+                </div>
+            </div>
+            <div class="form-group row">
+                <div class="col-md-3">
+                    <nop-override-store-checkbox asp-for="AzureBlobAppendContainerName_OverrideForStore" asp-input="AzureBlobAppendContainerName" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                    <nop-label asp-for="AzureBlobAppendContainerName" />
+                </div>
+                <div class="col-md-9">
+                    <nop-editor asp-for="AzureBlobAppendContainerName" />
+                    <span asp-validation-for="AzureBlobAppendContainerName"></span>
+                </div>
+            </div>
+            <hr />
+
             @if (Model.GeneratedFiles.Count > 0)
             {
                 <div class="form-group row">


### PR DESCRIPTION
Add Azure Blob Storage support to Google Shopping plugin

Introduced Azure Blob Storage support for storing the generated
Google Shopping feed XML file. Added new settings in
`GoogleShoppingSettings` to configure Azure Blob Storage, including
connection string, container name, and endpoint options.

Updated `FeedGoogleShoppingController` and `GoogleShoppingService`
to handle feed generation and dynamic URL serving based on storage
type. Added a new `GoogleShoppingFeedController` for serving feeds
from Azure Blob Storage or the local file system.

Registered a scheduled task (`GoogleShoppingFeedGenerateTask`) to
automate feed generation for all stores. Updated the plugin's
installation and uninstallation processes to handle the new
functionality. Enhanced the admin UI and localization resources to
support Azure Blob Storage configuration.

These changes improve scalability, persistence, and flexibility,
making the plugin suitable for cloud-based deployments.