### PR TITLE
Style old prices and improve CSS organization

### DIFF
--- a/src/Presentation/Nop.Web/Themes/TheSolidInspired/Content/css/custom_v2.css
+++ b/src/Presentation/Nop.Web/Themes/TheSolidInspired/Content/css/custom_v2.css
@@ -865,6 +865,17 @@ h6 {
   font-size: 1.1rem;
 }
 
+.prices .old-price,
+.old-product-price,
+.non-discounted-price {
+  text-decoration: line-through;
+  color: #999 !important;
+  font-weight: 400 !important;
+  font-size: 0.9rem !important;
+  margin-inline-end: 8px;
+}
+
+
 /* --- SIDEBAR & REDUNDANCY --- */
 .side-2,
 .menu-container,


### PR DESCRIPTION
Style old prices and improve CSS organization

Added a new CSS rule to style `.prices .old-price`, `.old-product-price`, and `.non-discounted-price` with a strikethrough, gray color, adjusted font weight, size, and margin for better visual distinction.

Introduced a comment (`/* --- SIDEBAR & REDUNDANCY --- */`) to improve the organization of the CSS file by categorizing related styles.