### PR TITLE
Add UniversalCommerce plugin for Google AP2 integration

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -95,7 +95,8 @@ jobs:
             { "SystemName": "Widgets.ShoppableBanner", "Version": "1.00" },
             { "SystemName": "Misc.MegaMenu", "Version": "1.00"},
             { "SystemName": "Feed.GoogleShopping", "Version": "5.00.2"},
-            { "SystemName": "Widgets.SeoEnhancements","Version": "1.00"}
+            { "SystemName": "Widgets.SeoEnhancements","Version": "1.00"},
+            { "SystemName": "Misc.UniversalCommerce","Version": "1.00"}
           ],
           "PluginNamesToUninstall": [],
           "PluginNamesToDelete": [],

--- a/src/NopCommerce.sln
+++ b/src/NopCommerce.sln
@@ -109,6 +109,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nop.Plugin.Feed.GoogleShopp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nop.Plugin.Widgets.SeoEnhancements", "Plugins\Nop.Plugin.Widgets.SeoEnhancements\Nop.Plugin.Widgets.SeoEnhancements.csproj", "{27E421E6-5630-D81D-5FB8-D4EF4A617A86}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nop.Plugin.Misc.UniversalCommerce", "Plugins\Nop.Plugin.Misc.UniversalCommerce\Nop.Plugin.Misc.UniversalCommerce.csproj", "{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nop.Plugin.Misc.UniversalCommerce.Tests", "Tests\Nop.Plugin.Misc.UniversalCommerce.Tests\Nop.Plugin.Misc.UniversalCommerce.Tests.csproj", "{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -883,6 +887,38 @@ Global
 		{27E421E6-5630-D81D-5FB8-D4EF4A617A86}.Release|x64.Build.0 = Release|Any CPU
 		{27E421E6-5630-D81D-5FB8-D4EF4A617A86}.Release|x86.ActiveCfg = Release|Any CPU
 		{27E421E6-5630-D81D-5FB8-D4EF4A617A86}.Release|x86.Build.0 = Release|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Debug|x64.Build.0 = Debug|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Debug|x86.Build.0 = Debug|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Release|x64.ActiveCfg = Release|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Release|x64.Build.0 = Release|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Release|x86.ActiveCfg = Release|Any CPU
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052}.Release|x86.Build.0 = Release|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Debug|x64.Build.0 = Debug|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Debug|x86.Build.0 = Debug|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Release|x64.ActiveCfg = Release|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Release|x64.Build.0 = Release|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Release|x86.ActiveCfg = Release|Any CPU
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -936,6 +972,8 @@ Global
 		{30C9D193-6999-A53C-768C-2388E0C32FCD} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 		{6F6CD4F4-7692-9715-66CF-98E32941D5F9} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 		{27E421E6-5630-D81D-5FB8-D4EF4A617A86} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
+		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
+		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF} = {E8FC6874-E230-468A-9685-4747354B92FF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EE72A8B2-332A-4175-9319-6726D36E9D25}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/AgentUniversalPaymentProcessor.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/AgentUniversalPaymentProcessor.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Nop.Core.Domain.Orders;
+using Nop.Services.Payments;
+using Nop.Services.Plugins;
+using Nop.Core.Domain.Payments;
+
+namespace Nop.Plugin.Misc.UniversalCommerce
+{
+    public class AgentUniversalPaymentProcessor : BasePlugin, IPaymentMethod
+    {
+        // Tell the admin configuration system where your entry page button points
+        public override string GetConfigurationPageUrl()
+        {
+            return "/Admin/UcpAdmin/Configure";
+        }
+
+        #region IPaymentMethod Implementation
+
+        /// <summary>
+        /// Processes the payment programmatically when the checkout API calls PlaceOrderAsync
+        /// </summary>
+        public Task<ProcessPaymentResult> ProcessPaymentAsync(ProcessPaymentRequest processPaymentRequest)
+        {
+            var result = new ProcessPaymentResult();
+
+            // Extract the cryptographic token passed from your API controller
+            if (!processPaymentRequest.CustomValues.TryGetValue("Ap2Token", out var ap2TokenObj) ||
+                string.IsNullOrEmpty(ap2TokenObj?.ToString()))
+            {
+                result.AddError("Google AP2 Payment Token is missing from the checkout payload.");
+                return Task.FromResult(result);
+            }
+
+            // In production, your token validation service should verify Google's signature here.
+            // If valid, immediately complete the transaction state.
+            result.NewPaymentStatus = PaymentStatus.Authorized;
+
+            // Store the token or reference ID directly on the order record for future reference
+            result.AuthorizationTransactionId = $"AP2-{Guid.NewGuid():N}";
+
+            return Task.FromResult(result);
+        }
+
+        /// <summary>
+        /// Post-payment processing (Used for standard browser redirects, skip for headless/agent transactions)
+        /// </summary>
+        public Task PostProcessPaymentAsync(PostProcessPaymentRequest postProcessPaymentRequest)
+        {
+            // Do nothing as the transaction completes entirely on the initial API call
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> HidePaymentMethodAsync(IList<ShoppingCartItem> cart)
+        {
+            return Task.FromResult(false);
+        }
+
+        public Task<decimal> GetAdditionalHandlingFeeAsync(IList<ShoppingCartItem> cart)
+        {
+            return Task.FromResult(0m);
+        }
+
+        public Task<ProcessPaymentResult> ProcessRecurringPaymentAsync(ProcessPaymentRequest processPaymentRequest)
+        {
+            var result = new ProcessPaymentResult();
+            result.AddError("Recurring payment not supported");
+            return Task.FromResult(result);
+        }
+
+        public Task<CancelRecurringPaymentResult> CancelRecurringPaymentAsync(CancelRecurringPaymentRequest cancelPaymentRequest)
+        {
+            var result = new CancelRecurringPaymentResult();
+            result.AddError("Recurring payment not supported");
+            return Task.FromResult(result);
+        }
+
+        public Task<bool> CanRePostProcessPaymentAsync(Order order)
+        {
+            return Task.FromResult(false);
+        }
+
+        public Task<IList<string>> ValidatePaymentFormAsync(IFormCollection form)
+        {
+            return Task.FromResult<IList<string>>(new List<string>());
+        }
+
+        public Task<ProcessPaymentRequest> GetPaymentInfoAsync(IFormCollection form)
+        {
+            return Task.FromResult(new ProcessPaymentRequest());
+        }
+
+        /// <summary>
+        /// Captures an authorized transaction (Called during shipping or automated settlement)
+        /// </summary>
+        public Task<CapturePaymentResult> CaptureAsync(CapturePaymentRequest capturePaymentRequest)
+        {
+            var result = new CapturePaymentResult
+            {
+                NewPaymentStatus = PaymentStatus.Paid,
+                CaptureTransactionId = capturePaymentRequest.Order.AuthorizationTransactionId
+            };
+            return Task.FromResult(result);
+        }
+
+        public Task<VoidPaymentResult> VoidAsync(VoidPaymentRequest voidPaymentRequest)
+        {
+            return Task.FromResult(new VoidPaymentResult { NewPaymentStatus = PaymentStatus.Voided });
+        }
+
+        public Task<RefundPaymentResult> RefundAsync(RefundPaymentRequest refundPaymentRequest)
+        {
+            return Task.FromResult(new RefundPaymentResult { NewPaymentStatus = PaymentStatus.Refunded });
+        }
+
+        #endregion
+
+        #region Properties & Configurations
+
+        // Set to true so nopCommerce allows capturing authorized funds
+        public bool SupportCapture => true;
+        public bool SupportPartiallyRefund => false;
+        public bool SupportRefund => true;
+        public bool SupportVoid => true;
+        public RecurringPaymentType RecurringPaymentType => RecurringPaymentType.NotSupported;
+        public PaymentMethodType PaymentMethodType => PaymentMethodType.Standard;
+        public bool SkipPaymentInfo => true;
+
+        public Task<string> GetPaymentMethodDescriptionAsync()
+        {
+            return Task.FromResult("Processes headless orders via Google Agent Payments Protocol (AP2).");
+        }
+
+        // Must match the system name used in your controller mapping exactly
+        public string PaymentMethodSystemName => "Payments.AgentUniversal";
+
+        #endregion
+
+        #region View Components (Skip UI Rendering)
+
+        public Type GetPublicViewComponent()
+        {
+            return null; // Headless integration, no UI rendered
+        }
+
+        #endregion
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Controllers/UcpAdminController.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Controllers/UcpAdminController.cs
@@ -1,0 +1,68 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Nop.Core.Configuration;
+using Nop.Plugin.Misc.UniversalCommerce.Domain;
+using Nop.Plugin.Misc.UniversalCommerce.Models;
+using Nop.Services.Messages;
+using Nop.Services.Configuration;
+using Nop.Web.Framework;
+using Nop.Web.Framework.Controllers;
+using Nop.Web.Framework.Mvc.Filters;
+
+namespace Nop.Plugin.Misc.UniversalCommerce.Controllers
+{
+    [AuthorizeAdmin]
+    [Area(AreaNames.ADMIN)]
+    [AutoValidateAntiforgeryToken]
+    public class UcpAdminController : BasePluginController
+    {
+        private readonly ISettingService _settingService;
+        private readonly INotificationService _notificationService;
+        private readonly UcpSettings _ucpSettings;
+
+        public UcpAdminController(
+            ISettingService settingService,
+            INotificationService notificationService,
+            UcpSettings ucpSettings)
+        {
+            _settingService = settingService;
+            _notificationService = notificationService;
+            _ucpSettings = ucpSettings;
+        }
+
+        [HttpGet]
+        public IActionResult Configure()
+        {
+            var model = new ConfigurationModel
+            {
+                Enabled = _ucpSettings.Enabled,
+                ProtocolVersion = _ucpSettings.ProtocolVersion,
+                AllowAutonomousCheckout = _ucpSettings.AllowAutonomousCheckout,
+                PermitLimit = _ucpSettings.PermitLimit,
+                WindowInSeconds = _ucpSettings.WindowInSeconds,
+                QueueLimit = _ucpSettings.QueueLimit
+            };
+
+            return View("~/Plugins/Misc.UniversalCommerce/Views/Configure.cshtml", model);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Configure(ConfigurationModel model)
+        {
+            if (!ModelState.IsValid) return Configure();
+
+            // Map UI updates back onto the persistent settings instance
+            _ucpSettings.Enabled = model.Enabled;
+            _ucpSettings.ProtocolVersion = model.ProtocolVersion;
+            _ucpSettings.AllowAutonomousCheckout = model.AllowAutonomousCheckout;
+            _ucpSettings.PermitLimit = model.PermitLimit;
+            _ucpSettings.WindowInSeconds = model.WindowInSeconds;
+            _ucpSettings.QueueLimit = model.QueueLimit;
+
+            await _settingService.SaveSettingAsync(_ucpSettings);
+            _notificationService.SuccessNotification("Google Universal Commerce configurations updated successfully.");
+
+            return Configure();
+        }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Controllers/UcpApiController.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Controllers/UcpApiController.cs
@@ -1,0 +1,268 @@
+using Microsoft.AspNetCore.Mvc;
+using Nop.Core;
+using Nop.Core.Domain.Orders;
+using Nop.Services.Catalog;
+using Nop.Services.Customers;
+using Nop.Services.Directory;
+using Nop.Services.Logging;
+using Nop.Services.Orders;
+using Nop.Services.Seo;
+using Nop.Core.Infrastructure;
+using Nop.Plugin.Misc.UniversalCommerce.Domain;
+using Nop.Plugin.Misc.UniversalCommerce.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Nop.Web.Framework.Controllers;
+using Nop.Plugin.Misc.UniversalCommerce.Extensions;
+using Nop.Services.Payments;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace Nop.Plugin.Misc.UniversalCommerce.Controllers
+{
+    [EnableRateLimiting("UcpAgentPolicy")] // Enforces limits across all endpoint routes inside this controller
+    public class UcpApiController : BasePluginController
+    {
+        private readonly IProductService _productService;
+        private readonly ICustomerService _customerService;
+        private readonly IShoppingCartService _shoppingCartService;
+        private readonly IOrderProcessingService _orderProcessingService;
+        private readonly ICountryService _countryService;
+        private readonly IStoreContext _storeContext;
+        private readonly IUrlRecordService _urlRecordService;
+        private readonly ILogger _logger; // Native nopCommerce Logger service reference
+
+        private readonly UcpSettings _ucpSettings;
+
+        public UcpApiController(
+            IProductService productService,
+            ICustomerService customerService,
+            IShoppingCartService shoppingCartService,
+            IOrderProcessingService orderProcessingService,
+            ICountryService countryService,
+            IStoreContext storeContext,
+            IUrlRecordService urlRecordService,
+            ILogger logger,
+            UcpSettings ucpSettings)
+        {
+            _productService = productService;
+            _customerService = customerService;
+            _shoppingCartService = shoppingCartService;
+            _orderProcessingService = orderProcessingService;
+            _countryService = countryService;
+            _storeContext = storeContext;
+            _urlRecordService = urlRecordService;
+            _logger = logger;
+            _ucpSettings = ucpSettings;
+        }
+
+        [HttpGet]
+        public IActionResult GetManifest()
+        {
+            // Verify if your business has toggled agentic traffic off
+            if (!_ucpSettings.Enabled)
+            {
+                return NotFound(new { error = "Agentic Commerce endpoints are currently disabled." });
+            }
+
+            // Construct the standardized schema payload expected by crawling agents
+            var manifest = new
+            {
+                ucp_version = _ucpSettings.ProtocolVersion,
+                capabilities = new
+                {
+                    product_discovery = true,
+                    realtime_inventory = true,
+                    agent_checkout = _ucpSettings.AllowAutonomousCheckout
+                },
+                endpoints = new
+                {
+                    catalog_discovery = "/api/ucp/catalog",
+                    inventory_check = "/api/ucp/inventory",
+                    cart_management = "/api/ucp/cart",
+                    payment_handshake = "/api/ucp/checkout"
+                }
+            };
+
+            // Enforce response headers to match specific standard security profiles
+            Response.Headers["Access-Control-Allow-Origin"] = "*";
+            Response.Headers["Cache-Control"] = "public, max-age=86400"; // Cache for 24 hours
+
+            return Json(manifest);
+        }
+
+        [HttpPost]
+        [Route("api/ucp/inventory")]
+        public async Task<IActionResult> CheckInventory([FromBody] UcpInventoryRequest request)
+        {
+            var product = await _productService.GetProductBySkuAsync(request.Sku);
+            if (product == null)
+                return NotFound(new { error = "SKU not found." });
+
+            bool isAvailable = product.Published &&
+                               (!product.ManageInventoryMethodId.Equals(1) || product.StockQuantity >= request.Quantity);
+
+            // Evaluate identical delivery rules on inquiry
+            decimal subTotal = product.Price * request.Quantity;
+            decimal expectedShipping = subTotal >= 40.00m ? 0.00m : 3.85m;
+
+            return Json(new
+            {
+                sku = product.Sku,
+                available = isAvailable,
+                price = product.Price,
+                currency = "GBP",
+                shipping_options = new[] {
+            new {
+                id = expectedShipping == 0.00m ? "free_shipping" : "standard_shipping",
+                label = expectedShipping == 0.00m ? "Free Delivery" : "Standard Delivery",
+                cost = expectedShipping
+            }
+        }
+            });
+        }
+
+        [HttpGet]
+        [Route("api/ucp/catalog")]
+        public async Task<IActionResult> GetCatalog([FromQuery] int pageIndex = 0, [FromQuery] int pageSize = 50)
+        {
+            // Enforce maximum safe boundaries on bulk size demands
+            if (pageSize > 250)
+                pageSize = 250;
+            if (pageIndex < 0)
+                pageIndex = 0;
+
+            var currentStore = await _storeContext.GetCurrentStoreAsync();
+
+            // Fetch an optimized page slice targeting simple published database entities
+            var productsPage = await _productService.SearchProductsAsync(
+                pageIndex: pageIndex,
+                pageSize: pageSize,
+                storeId: currentStore.Id,
+                visibleIndividuallyOnly: true,
+                overridePublished: true // Passing true ensures it enforces the 'Published = true' filter internally
+            );
+
+            var items = new List<UcpCatalogItem>();
+
+            foreach (var product in productsPage)
+            {
+                // Discard entries missing identifiers required by AI agents
+                if (string.IsNullOrWhiteSpace(product.Sku))
+                    continue;
+
+                // Evaluate inventory state using your simple logic parameters
+                bool inStock = !product.ManageInventoryMethodId.Equals(1) || product.StockQuantity > 0;
+
+                // Retrieve the SEO-friendly URL Slug for linking references directly
+                var slug = await _urlRecordService.GetSeNameAsync(product);
+
+                items.Add(new UcpCatalogItem
+                {
+                    Sku = product.Sku,
+                    Name = product.Name,
+                    Description = product.ShortDescription ?? product.Name,
+                    Price = product.Price,
+                    InStock = inStock,
+                    UrlSlug = slug
+                });
+            }
+
+            var response = new UcpCatalogResponse
+            {
+                TotalItems = productsPage.TotalCount,
+                PageIndex = productsPage.PageIndex,
+                HasNextPage = productsPage.HasNextPage,
+                Products = items
+            };
+
+            return Json(response);
+        }
+
+        [HttpPost]
+        [Route("api/ucp/checkout")]
+        public async Task<IActionResult> AgentCheckout([FromBody] Ap2CheckoutRequest request)
+        {
+            // Log the initial checkout intent step
+            await _logger.LogAgentActivityAsync("CheckoutIntent", request.Sku, $"Agent initiated a transaction request for user {request.Email}");
+
+            var product = await _productService.GetProductBySkuAsync(request.Sku);
+            if (product == null)
+            {
+                await _logger.LogAgentActivityAsync("CheckoutFailed", request.Sku, $"Transaction rejected: SKU does not exist.");
+                return NotFound(new { error = "SKU invalid." });
+            }
+
+            if (string.IsNullOrEmpty(request.PaymentToken))
+                return BadRequest(new { error = "AP2 token required." });
+
+            // Enforce your precise £3.85 / Free if >= £40 business rule
+            decimal subTotal = product.Price * request.Quantity;
+            decimal shippingCost = subTotal >= 40.00m ? 0.00m : 3.85m;
+            decimal totalCost = subTotal + shippingCost;
+
+            var customer = await _customerService.GetCustomerByEmailAsync(request.Email);
+            if (customer == null)
+            {
+                customer = await _customerService.InsertGuestCustomerAsync();
+                customer.Email = request.Email;
+                await _customerService.UpdateCustomerAsync(customer);
+            }
+
+            var country = await _countryService.GetCountryByTwoLetterIsoCodeAsync(request.ShippingAddress.CountryTwoLetterIsoCode);
+            var address = new Nop.Core.Domain.Common.Address
+            {
+                FirstName = request.ShippingAddress.FirstName,
+                LastName = request.ShippingAddress.LastName,
+                Address1 = request.ShippingAddress.Address1,
+                City = request.ShippingAddress.City,
+                ZipPostalCode = request.ShippingAddress.ZipPostalCode,
+                CountryId = country?.Id ?? 0,
+                CreatedOnUtc = DateTime.UtcNow
+            };
+            customer.BillingAddressId = address.Id;
+            customer.ShippingAddressId = address.Id;
+
+            await _shoppingCartService.AddToCartAsync(customer, product, ShoppingCartType.ShoppingCart, 1, quantity: request.Quantity);
+
+            var processPaymentRequest = new ProcessPaymentRequest
+            {
+                OrderGuid = Guid.NewGuid(),
+                CustomerId = customer.Id,
+                PaymentMethodSystemName = "Payments.AgentUniversal",
+                OrderTotal = totalCost
+            };
+            processPaymentRequest.CustomValues["Ap2Token"] = request.PaymentToken;
+            processPaymentRequest.CustomValues["TargetSku"] = request.Sku;
+
+            var placeOrderResult = await _orderProcessingService.PlaceOrderAsync(processPaymentRequest);
+
+            if (placeOrderResult.Success)
+            {
+                var order = placeOrderResult.PlacedOrder;
+                order.OrderShippingInclTax = shippingCost;
+                order.OrderShippingExclTax = shippingCost;
+                order.ShippingMethod = shippingCost == 0.00m ? "Free Shipping" : "Standard Shipping";
+
+                // Log the final checkout success milestone along with customer details
+                await _logger.LogAgentActivityAsync(
+                    activityType: "CheckoutSuccess",
+                    sku: request.Sku,
+                    message: $"Order #{order.Id} placed successfully via AP2 handshake.",
+                    customer: customer
+                );
+
+                return Ok(new { success = true, order_id = order.Id, charged = totalCost });
+            }
+
+            // Log any errors that caused the transaction to fail
+            string errorsList = string.Join(" | ", placeOrderResult.Errors);
+            await _logger.LogAgentActivityAsync("CheckoutFailed", request.Sku, $"Order placement failed with errors: {errorsList}", customer);
+
+            return BadRequest(new { error = "Order failed.", details = placeOrderResult.Errors });
+        }
+    }
+
+    public record Ap2CheckoutRequest(string Sku, int Quantity, string Email, string PaymentToken, Ap2Addr ShippingAddress);
+    public record Ap2Addr(string FirstName, string LastName, string Address1, string City, string ZipPostalCode, string CountryTwoLetterIsoCode);
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Domain/UcpSettings.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Domain/UcpSettings.cs
@@ -1,0 +1,14 @@
+using Nop.Core.Configuration;
+
+namespace Nop.Plugin.Misc.UniversalCommerce.Domain
+{
+    public class UcpSettings : ISettings
+    {
+        public bool Enabled { get; set; } = true;
+        public string ProtocolVersion { get; set; } = "1.0";
+        public bool AllowAutonomousCheckout { get; set; } = true;
+        public int PermitLimit { get; set; } = 100;
+        public int WindowInSeconds { get; set; } = 60;
+        public int QueueLimit { get; set; } = 10;
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Extensions/LoggerExtensions.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Extensions/LoggerExtensions.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Nop.Core.Domain.Customers;
+using Nop.Services.Logging;
+
+namespace Nop.Plugin.Misc.UniversalCommerce.Extensions
+{
+    public static class LoggerExtensions
+    {
+        /// <summary>
+        /// Logs a structured Agentic Commerce transaction event safely to the core database tables
+        /// </summary>
+        public static async Task LogAgentActivityAsync(
+            this ILogger logger,
+            string activityType,
+            string sku,
+            string message,
+            Customer? customer = null)
+        {
+            // Build a structured payload to ensure easy log parsing later
+            var structuredPayload = new
+            {
+                Timestamp = DateTime.UtcNow,
+                Source = "GoogleAgenticCommerce",
+                Activity = activityType,
+                TargetSku = sku,
+                Details = message
+            };
+
+            string fullMessage = JsonSerializer.Serialize(structuredPayload);
+            string shortMessage = $"UCP Agent Event: {activityType} for SKU [{sku}]";
+
+            // Insert directly into the native nopCommerce DB Log tables
+            await logger.InformationAsync(
+                message: shortMessage + " - " + fullMessage,
+                customer: customer
+            );
+        }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Infrastructure/NopStartup.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Infrastructure/NopStartup.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Caching.Hybrid; // Required for .NET 10 HybridCache config
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nop.Core.Infrastructure;
+using Nop.Plugin.Misc.UniversalCommerce.Domain;
+using Nop.Plugin.Misc.UniversalCommerce.Services;
+
+namespace Nop.Plugin.Misc.UniversalCommerce.Infrastructure
+{
+    public class NopStartup : INopStartup
+    {
+        public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+        {
+            // 1. Register HttpClient required by your public key fetching routines
+            services.AddHttpClient();
+
+            // 2. Register .NET 10 HybridCache with a safe global maximum payload size
+#pragma warning disable EXTEXP0018 // HybridCache is marked preview/experimental in some early .NET 10 builds
+            services.AddHybridCache(options =>
+            {
+                // Prevent malicious agents from flooding cache blocks with massive keys
+                options.MaximumPayloadBytes = 1024 * 1024; // 1MB max cache entry sizing
+                options.DefaultEntryOptions = new HybridCacheEntryOptions
+                {
+                    Expiration = TimeSpan.FromHours(24) // Optimal duration for Google signature keys
+                    // LocalCacheExpiration is not strictly necessary or might be named differently
+                };
+            });
+#pragma warning restore EXTEXP0018
+
+            // 3. Register your cryptographic token validator
+            services.AddScoped<IAp2SecurityService, Ap2SecurityService>();
+
+            // 4. Set up rate-limiting rules using your custom UcpSettings records dynamically per request
+            services.AddRateLimiter(options =>
+            {
+                options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+                options.OnRejected = async (context, token) =>
+                {
+                    context.HttpContext.Response.ContentType = "application/json";
+                    await context.HttpContext.Response.WriteAsync(
+                        "{\"error\": \"Too many requests. Agent traffic threshold exceeded.\"}",
+                        cancellationToken: token);
+                };
+
+                options.AddPolicy("UcpAgentPolicy", context =>
+                {
+                    // Resolve settings dynamically at runtime per request to avoid null DI contexts at startup
+                    var ucpSettings = context.RequestServices.GetRequiredService<UcpSettings>();
+                    return RateLimitPartition.GetFixedWindowLimiter("UcpAgentPolicy", partition => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = ucpSettings.PermitLimit > 0 ? ucpSettings.PermitLimit : 100,
+                        Window = TimeSpan.FromSeconds(ucpSettings.WindowInSeconds > 0 ? ucpSettings.WindowInSeconds : 60),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = ucpSettings.QueueLimit >= 0 ? ucpSettings.QueueLimit : 0
+                    });
+                });
+            });
+        }
+
+        public void Configure(IApplicationBuilder application)
+        {
+            // nopCommerce natively injects application.UseRateLimiter() via Nop.Web.Framework,
+            // so we do not need to register it again here.
+        }
+
+        // Must execute high enough in the stack sequence to handle requests before standard UI routing catches them
+        public int Order => 400;
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Infrastructure/RouteProvider.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Infrastructure/RouteProvider.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Nop.Web.Framework.Mvc.Routing;
+
+namespace Nop.Plugin.Misc.UniversalCommerce.Infrastructure
+{
+    public class RouteProvider : IRouteProvider
+    {
+        public void RegisterRoutes(IEndpointRouteBuilder endpointRouteBuilder)
+        {
+            // Standard root path handling for the Google Agent crawler
+            endpointRouteBuilder.MapControllerRoute(
+                name: "Plugin.Misc.UniversalCommerce.WellKnown",
+                pattern: ".well-known/ucp",
+                defaults: new { controller = "UcpApi", action = "GetManifest" });
+
+            endpointRouteBuilder.MapControllerRoute(
+                name: "Plugin.Misc.UniversalCommerce.Catalog",
+                pattern: "api/ucp/catalog",
+                defaults: new { controller = "UcpApi", action = "GetCatalog" });
+
+            endpointRouteBuilder.MapControllerRoute(
+                name: "Plugin.Misc.UniversalCommerce.Checkout",
+                pattern: "api/ucp/checkout",
+                defaults: new { controller = "UcpApi", action = "AgentCheckout" });
+        }
+
+        public int Priority => 3000; // Overrides basic route evaluation bindings
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/Ap2CheckoutModels.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/Ap2CheckoutModels.cs
@@ -1,0 +1,18 @@
+﻿public class Ap2CheckoutRequest
+{
+    public string Sku { get; set; }
+    public int Quantity { get; set; }
+    public string Email { get; set; }
+    public Ap2Address ShippingAddress { get; set; }
+    public string PaymentToken { get; set; } // The cryptographic authorization token
+}
+
+public class Ap2Address
+{
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public string Address1 { get; set; }
+    public string City { get; set; }
+    public string ZipPostalCode { get; set; }
+    public string CountryTwoLetterIsoCode { get; set; }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/Ap2SecurityModels.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/Ap2SecurityModels.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+
+namespace Nop.Plugin.Misc.UniversalCommerce.Models
+{
+    public class Ap2TokenPayload
+    {
+        [JsonPropertyName("signature")]
+        public string Signature { get; set; }
+
+        [JsonPropertyName("protocolVersion")]
+        public string ProtocolVersion { get; set; } // ECv2 or AP2-v1
+
+        [JsonPropertyName("signedMessage")]
+        public string SignedMessage { get; set; } // JSON string containing Mandate and Cart
+    }
+
+    public class Ap2SignedMessage
+    {
+        [JsonPropertyName("mandateId")]
+        public string MandateId { get; set; }
+
+        [JsonPropertyName("intentEnvelope")]
+        public string IntentEnvelope { get; set; }
+
+        [JsonPropertyName("cartDetails")]
+        public Ap2CartDetails CartDetails { get; set; }
+    }
+
+    public class Ap2CartDetails
+    {
+        [JsonPropertyName("sku")]
+        public string Sku { get; set; }
+
+        [JsonPropertyName("expectedPrice")]
+        public decimal ExpectedPrice { get; set; }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/ConfigurationModel.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/ConfigurationModel.cs
@@ -1,0 +1,26 @@
+using Nop.Web.Framework.Models;
+using Nop.Web.Framework.Mvc.ModelBinding;
+
+namespace Nop.Plugin.Misc.UniversalCommerce.Models
+{
+    public record ConfigurationModel : BaseNopModel
+    {
+        [NopResourceDisplayName("Plugins.Misc.UniversalCommerce.Fields.Enabled")]
+        public bool Enabled { get; set; }
+
+        [NopResourceDisplayName("Plugins.Misc.UniversalCommerce.Fields.ProtocolVersion")]
+        public string ProtocolVersion { get; set; }
+
+        [NopResourceDisplayName("Plugins.Misc.UniversalCommerce.Fields.AllowAutonomousCheckout")]
+        public bool AllowAutonomousCheckout { get; set; }
+
+        [NopResourceDisplayName("Plugins.Misc.UniversalCommerce.Fields.PermitLimit")]
+        public int PermitLimit { get; set; }
+
+        [NopResourceDisplayName("Plugins.Misc.UniversalCommerce.Fields.WindowInSeconds")]
+        public int WindowInSeconds { get; set; }
+
+        [NopResourceDisplayName("Plugins.Misc.UniversalCommerce.Fields.QueueLimit")]
+        public int QueueLimit { get; set; }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/UcpCatalogModels.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/UcpCatalogModels.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Nop.Plugin.Misc.UniversalCommerce.Models
+{
+    public class UcpCatalogResponse
+    {
+        [JsonPropertyName("total_items")]
+        public int TotalItems { get; set; }
+
+        [JsonPropertyName("page_index")]
+        public int PageIndex { get; set; }
+
+        [JsonPropertyName("has_next_page")]
+        public bool HasNextPage { get; set; }
+
+        [JsonPropertyName("products")]
+        public List<UcpCatalogItem> Products { get; set; }
+    }
+
+    public class UcpCatalogItem
+    {
+        [JsonPropertyName("sku")]
+        public string Sku { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+
+        [JsonPropertyName("price")]
+        public decimal Price { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; } = "GBP";
+
+        [JsonPropertyName("in_stock")]
+        public bool InStock { get; set; }
+
+        [JsonPropertyName("url_slug")]
+        public string UrlSlug { get; set; }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/UcpInventoryRequest.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/UcpInventoryRequest.cs
@@ -1,0 +1,8 @@
+namespace Nop.Plugin.Misc.UniversalCommerce.Models
+{
+    public class UcpInventoryRequest
+    {
+        public string Sku { get; set; } = string.Empty;
+        public int Quantity { get; set; }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Nop.Plugin.Misc.UniversalCommerce.csproj
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Nop.Plugin.Misc.UniversalCommerce.csproj
@@ -1,0 +1,64 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Copyright>Derrick Madden</Copyright>
+    <RootNamespace>Nop.Plugin.Misc.UniversalCommerce</RootNamespace>
+    <AssemblyName>Nop.Plugin.Misc.UniversalCommerce</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Copy plugin output to nopCommerce plugins folder on build -->
+    <OutputPath>..\..\Presentation\Nop.Web\Plugins\Misc.UniversalCommerce\</OutputPath>
+    <OutDir>$(OutputPath)</OutDir>
+    <!-- Copy NuGet references locally for dynamic loading -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.7.0" />
+    <ProjectReference Include="..\..\Presentation\Nop.Web.Framework\Nop.Web.Framework.csproj" />
+    <ProjectReference Include="..\..\Presentation\Nop.Web\Nop.Web.csproj" />
+    <ProjectReference Include="..\..\Libraries\Nop.Services\Nop.Services.csproj" />
+    <ProjectReference Include="..\..\Libraries\Nop.Data\Nop.Data.csproj" />
+    <ProjectReference Include="..\..\Libraries\Nop.Core\Nop.Core.csproj" />
+    <ClearPluginAssemblies Include="$(MSBuildProjectDirectory)\..\..\Build\ClearPluginAssemblies.proj" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+  </ItemGroup>
+
+  <!-- Embed plugin.json and static assets -->
+  <ItemGroup>
+    <None Update="plugin.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="wwwroot\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <Content Include="Views\**\*.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Infrastructure\UcpApiController.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Infrastructure\UcpApiController.cs" />
+  </ItemGroup>
+
+  <!--
+    Also copy wwwroot into Nop.Web/wwwroot/Plugins/Misc.UniversalCommerce/ at build time.
+    nopCommerce serves plugin static files from there, not from the plugin bin folder.
+    Without this, CSS/JS 404 even though the plugin loads fine.
+  -->
+  <Target Name="CopyPluginStaticFiles" AfterTargets="Build">
+    <ItemGroup>
+      <PluginStaticFiles Include="wwwroot\**\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(PluginStaticFiles)" DestinationFiles="@(PluginStaticFiles->'..\..\Presentation\Nop.Web\wwwroot\Plugins\Misc.UniversalCommerce\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- This target executes after "Build" target to clear redundant assemblies -->
+  <Target Name="NopTarget" AfterTargets="Build">
+    <MSBuild Projects="@(ClearPluginAssemblies)" Properties="PluginPath=$(OutDir)" Targets="NopClear" />
+  </Target>
+
+</Project>

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Services/Ap2SecurityService.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Services/Ap2SecurityService.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Nop.Plugin.Misc.UniversalCommerce.Models;
+using Microsoft.Extensions.Caching.Hybrid; // Native to modern .NET runtimes
+
+namespace Nop.Plugin.Misc.UniversalCommerce.Services
+{
+    public class Ap2SecurityService : IAp2SecurityService
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly HybridCache _cache;
+        private const string GoogleAp2KeysUrl = "https://google.com";
+
+        public Ap2SecurityService(IHttpClientFactory httpClientFactory, HybridCache cache)
+        {
+            _httpClientFactory = httpClientFactory;
+            _cache = cache;
+        }
+
+        public async Task<string> GetGoogleKeysJsonAsync()
+        {
+            // HybridCache handles multi-thread token requests safely out of the box
+            return await _cache.GetOrCreateAsync("google-ap2-public-keys", async token =>
+            {
+                var client = _httpClientFactory.CreateClient();
+                return await client.GetStringAsync(GoogleAp2KeysUrl, token);
+            },
+            options: new HybridCacheEntryOptions
+            {
+                Expiration = TimeSpan.FromHours(24) // Google keys rotate infrequently
+            });
+        }
+        public async Task<bool> ValidateAgentMandateAsync(string rawTokenJson, decimal systemPrice, string expectedSku)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(rawTokenJson))
+                    return false;
+
+                // 1. Parse the incoming AP2 structure
+                var tokenEnvelope = JsonSerializer.Deserialize<Ap2TokenPayload>(rawTokenJson);
+                if (tokenEnvelope == null || string.IsNullOrEmpty(tokenEnvelope.Signature))
+                    return false;
+
+                // 2. Fetch Google's trusted signing public keys (Cache this in production)
+                var client = _httpClientFactory.CreateClient();
+                var keysResponse = await client.GetStringAsync(GoogleAp2KeysUrl);
+                using var keysDocument = JsonDocument.Parse(keysResponse);
+
+                // 3. Extract the inner signed message
+                var signedMessageBytes = Encoding.UTF8.GetBytes(tokenEnvelope.SignedMessage);
+                var signatureBytes = Convert.FromBase64String(tokenEnvelope.Signature);
+
+                // 4. Verify signature against Google's public key list
+                bool isSignatureValid = false;
+                foreach (var keyNode in keysDocument.RootElement.GetProperty("keys").EnumerateArray())
+                {
+                    if (keyNode.GetProperty("protocolVersion").GetString() != tokenEnvelope.ProtocolVersion)
+                        continue;
+
+                    var keyValue = keyNode.GetProperty("keyValue").GetString();
+                    var publicKeyBytes = Convert.FromBase64String(keyValue);
+
+                    using var ecdsa = ECDsa.Create();
+                    ecdsa.ImportSubjectPublicKeyInfo(publicKeyBytes, out _);
+
+                    if (ecdsa.VerifyData(signedMessageBytes, signatureBytes, HashAlgorithmName.SHA256))
+                    {
+                        isSignatureValid = true;
+                        break;
+                    }
+                }
+
+                if (!isSignatureValid)
+                    return false;
+
+                // 5. Audit validation (Prevent agent price tampering)
+                var payloadDetails = JsonSerializer.Deserialize<Ap2SignedMessage>(tokenEnvelope.SignedMessage);
+                if (payloadDetails == null || payloadDetails.CartDetails == null)
+                    return false;
+
+                if (payloadDetails.CartDetails.Sku != expectedSku)
+                    return false;
+                if (payloadDetails.CartDetails.ExpectedPrice != systemPrice)
+                    return false; // Thwart mid-flight price manipulation
+
+                return true;
+            }
+            catch
+            {
+                // In production, log specific exceptions to NopLogger
+                return false;
+            }
+        }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Services/IAp2SecurityService.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Services/IAp2SecurityService.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using Nop.Plugin.Misc.UniversalCommerce.Models;
+
+namespace Nop.Plugin.Misc.UniversalCommerce.Services
+{
+    public interface IAp2SecurityService
+    {
+        Task<string> GetGoogleKeysJsonAsync();
+        Task<bool> ValidateAgentMandateAsync(string rawTokenJson, decimal systemPrice, string expectedSku);
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/UniversalCommercePlugin.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/UniversalCommercePlugin.cs
@@ -1,0 +1,48 @@
+using Nop.Core;
+using Nop.Services.Plugins;
+using Nop.Services.Helpers;
+using Nop.Services.Localization;
+using System.Collections.Generic;
+
+namespace Nop.Plugin.Misc.UniversalCommerce;
+
+public class UniversalCommercePlugin : BasePlugin
+{
+    private readonly IWebHelper _webHelper;
+    private readonly ILocalizationService _localizationService;
+
+    public UniversalCommercePlugin(
+        IWebHelper webHelper,
+        ILocalizationService localizationService)
+    {
+        _webHelper = webHelper;
+        _localizationService = localizationService;
+    }
+
+    public override string GetConfigurationPageUrl()
+    {
+        return $"{_webHelper.GetStoreLocation()}Admin/UcpAdmin/Configure";
+    }
+
+    public override async Task InstallAsync()
+    {
+        await _localizationService.AddOrUpdateLocaleResourceAsync(new Dictionary<string, string>
+        {
+            ["Plugins.Misc.UniversalCommerce.Fields.Enabled"] = "Enable Google Agentic Commerce",
+            ["Plugins.Misc.UniversalCommerce.Fields.ProtocolVersion"] = "Protocol Version (e.g. ap2)",
+            ["Plugins.Misc.UniversalCommerce.Fields.AllowAutonomousCheckout"] = "Allow Autonomous Checkout",
+            ["Plugins.Misc.UniversalCommerce.Fields.PermitLimit"] = "Rate Limit (Permits per Window)",
+            ["Plugins.Misc.UniversalCommerce.Fields.WindowInSeconds"] = "Rate Limit Window (Seconds)",
+            ["Plugins.Misc.UniversalCommerce.Fields.QueueLimit"] = "Rate Limit Queue Size"
+        });
+
+        await base.InstallAsync();
+    }
+
+    public override async Task UninstallAsync()
+    {
+        await _localizationService.DeleteLocaleResourcesAsync("Plugins.Misc.UniversalCommerce");
+
+        await base.UninstallAsync();
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Views/Configure.cshtml
@@ -1,0 +1,56 @@
+@model Nop.Plugin.Misc.UniversalCommerce.Models.ConfigurationModel
+@{
+    Layout = "_AdminLayout";
+    ViewBag.PageTitle = "Google Agentic Commerce Configurations";
+}
+
+<form asp-controller="UcpAdmin" asp-action="Configure" method="post">
+    <div class="content-header clearfix">
+        <h1 class="float-left">Google Agentic Commerce Configurations</h1>
+        <div class="float-right">
+            <button type="submit" name="save" class="btn btn-primary">
+                <i class="far fa-save"></i> Save Changes
+            </button>
+        </div>
+    </div>
+
+    <section class="content">
+        <div class="container-fluid">
+            <div class="card card-default">
+                <div class="card-header">General Rules</div>
+                <div class="card-body">
+                    <div class="form-group row">
+                        <div class="col-md-3"><nop-label asp-for="Enabled" /></div>
+                        <div class="col-md-9"><nop-editor asp-for="Enabled" /></div>
+                    </div>
+                    <div class="form-group row">
+                        <div class="col-md-3"><nop-label asp-for="ProtocolVersion" /></div>
+                        <div class="col-md-9"><nop-editor asp-for="ProtocolVersion" /></div>
+                    </div>
+                    <div class="form-group row">
+                        <div class="col-md-3"><nop-label asp-for="AllowAutonomousCheckout" /></div>
+                        <div class="col-md-9"><nop-editor asp-for="AllowAutonomousCheckout" /></div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card card-default">
+                <div class="card-header">Agent Rate Limiting Thresholds</div>
+                <div class="card-body">
+                    <div class="form-group row">
+                        <div class="col-md-3"><nop-label asp-for="PermitLimit" /></div>
+                        <div class="col-md-9"><nop-editor asp-for="PermitLimit" /></div>
+                    </div>
+                    <div class="form-group row">
+                        <div class="col-md-3"><nop-label asp-for="WindowInSeconds" /></div>
+                        <div class="col-md-9"><nop-editor asp-for="WindowInSeconds" /></div>
+                    </div>
+                    <div class="form-group row">
+                        <div class="col-md-3"><nop-label asp-for="QueueLimit" /></div>
+                        <div class="col-md-9"><nop-editor asp-for="QueueLimit" /></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</form>

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Views/_ViewImports.cshtml
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Views/_ViewImports.cshtml
@@ -1,0 +1,14 @@
+@inherits Nop.Web.Framework.Mvc.Razor.NopRazorPage<TModel>
+
+@inject INopHtmlHelper NopHtml
+@inject INopUrlHelper NopUrl
+
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, Nop.Web.Framework
+
+@using Microsoft.AspNetCore.Mvc.ViewFeatures
+@using Nop.Web.Framework.Models
+@using Nop.Web.Framework.Models.DataTables
+@using Nop.Web.Framework.Mvc.Routing
+@using Nop.Web.Framework.UI
+@using Nop.Plugin.Misc.UniversalCommerce.Models

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/plugin.json
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/plugin.json
@@ -1,0 +1,11 @@
+{
+  "Group": "Misc",
+  "FriendlyName": "Google Agentic Commerce Integration",
+  "SystemName": "Misc.UniversalCommerce",
+  "Version": "1.00",
+  "SupportedVersions": [ "5.00" ],
+  "Author": "Derrick Madden",
+  "DisplayOrder": 1,
+  "FileName": "Nop.Plugin.Misc.UniversalCommerce.dll",
+  "Description": "Adds agentic shopping capability."
+}

--- a/src/Tests/Nop.Plugin.Misc.UniversalCommerce.Tests/Nop.Plugin.Misc.UniversalCommerce.Tests.csproj
+++ b/src/Tests/Nop.Plugin.Misc.UniversalCommerce.Tests/Nop.Plugin.Misc.UniversalCommerce.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\Nop.Plugin.Misc.UniversalCommerce\Nop.Plugin.Misc.UniversalCommerce.csproj" />
+    <ProjectReference Include="..\..\Libraries\Nop.Core\Nop.Core.csproj" />
+    <ProjectReference Include="..\..\Libraries\Nop.Services\Nop.Services.csproj" />
+    <ProjectReference Include="..\..\Presentation\Nop.Web.Framework\Nop.Web.Framework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/Nop.Plugin.Misc.UniversalCommerce.Tests/UcpApiControllerTests.cs
+++ b/src/Tests/Nop.Plugin.Misc.UniversalCommerce.Tests/UcpApiControllerTests.cs
@@ -1,0 +1,374 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Nop.Core;
+using Nop.Core.Domain.Catalog;
+using Nop.Core.Domain.Common;
+using Nop.Core.Domain.Customers;
+using Nop.Core.Domain.Directory;
+using Nop.Core.Domain.Orders;
+using Nop.Core.Domain.Stores;
+using Nop.Plugin.Misc.UniversalCommerce.Controllers;
+using Nop.Plugin.Misc.UniversalCommerce.Models;
+using Nop.Plugin.Misc.UniversalCommerce.Domain;
+using Nop.Services.Catalog;
+using Nop.Services.Customers;
+using Nop.Services.Directory;
+using Nop.Services.Logging;
+using Nop.Services.Orders;
+using Nop.Services.Seo;
+using Xunit;
+
+namespace Nop.Plugin.Misc.UniversalCommerce.Tests
+{
+    public class UcpApiControllerTests
+    {
+        private readonly Mock<IProductService> _productServiceMock;
+        private readonly Mock<ICustomerService> _customerServiceMock;
+        private readonly Mock<IShoppingCartService> _shoppingCartServiceMock;
+        private readonly Mock<IOrderProcessingService> _orderProcessingServiceMock;
+        private readonly Mock<ICountryService> _countryServiceMock;
+        private readonly Mock<IStoreContext> _storeContextMock;
+        private readonly Mock<IUrlRecordService> _urlRecordServiceMock;
+        private readonly Mock<ILogger> _loggerMock;
+        private readonly UcpSettings _ucpSettings;
+        private readonly UcpApiController _controller;
+
+        public UcpApiControllerTests()
+        {
+            _productServiceMock = new Mock<IProductService>();
+            _customerServiceMock = new Mock<ICustomerService>();
+            _shoppingCartServiceMock = new Mock<IShoppingCartService>();
+            _orderProcessingServiceMock = new Mock<IOrderProcessingService>();
+            _countryServiceMock = new Mock<ICountryService>();
+            _storeContextMock = new Mock<IStoreContext>();
+            _urlRecordServiceMock = new Mock<IUrlRecordService>();
+            _loggerMock = new Mock<ILogger>();
+            _ucpSettings = new UcpSettings { Enabled = true, ProtocolVersion = "1.0", AllowAutonomousCheckout = true };
+
+            _controller = new UcpApiController(
+                _productServiceMock.Object,
+                _customerServiceMock.Object,
+                _shoppingCartServiceMock.Object,
+                _orderProcessingServiceMock.Object,
+                _countryServiceMock.Object,
+                _storeContextMock.Object,
+                _urlRecordServiceMock.Object,
+                _loggerMock.Object,
+                _ucpSettings
+            );
+            
+            // Setup a dummy HttpContext so Response.Headers doesn't throw NullReferenceException
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+        }
+
+        [Fact]
+        public async Task CheckInventory_ReturnsFreeShipping_WhenSubTotalExceedsThreshold()
+        {
+            // Arrange
+            var sku = "TEST-1";
+            var request = new UcpInventoryRequest { Sku = sku, Quantity = 2 };
+            var product = new Product
+            {
+                Sku = sku,
+                Price = 25.00m,
+                Published = true,
+                ManageInventoryMethodId = 1, // Track inventory
+                StockQuantity = 10
+            };
+            
+            _productServiceMock.Setup(x => x.GetProductBySkuAsync(sku)).ReturnsAsync(product);
+
+            // Act
+            var result = await _controller.CheckInventory(request) as JsonResult;
+
+            // Assert
+            Assert.NotNull(result);
+            dynamic data = result.Value;
+            
+            // Validate availability
+            Assert.True((bool)data.GetType().GetProperty("available").GetValue(data, null));
+            
+            // Validate shipping option
+            var shippingOptions = data.GetType().GetProperty("shipping_options").GetValue(data, null);
+            var firstOption = (shippingOptions as Array).GetValue(0);
+            decimal cost = (decimal)firstOption.GetType().GetProperty("cost").GetValue(firstOption, null);
+            string id = (string)firstOption.GetType().GetProperty("id").GetValue(firstOption, null);
+            
+            Assert.Equal(0.00m, cost);
+            Assert.Equal("free_shipping", id);
+        }
+
+        [Fact]
+        public async Task CheckInventory_ReturnsStandardShipping_WhenSubTotalBelowThreshold()
+        {
+            // Arrange
+            var sku = "TEST-2";
+            var request = new UcpInventoryRequest { Sku = sku, Quantity = 1 };
+            var product = new Product
+            {
+                Sku = sku,
+                Price = 15.00m,
+                Published = true,
+                ManageInventoryMethodId = 1,
+                StockQuantity = 5
+            };
+            
+            _productServiceMock.Setup(x => x.GetProductBySkuAsync(sku)).ReturnsAsync(product);
+
+            // Act
+            var result = await _controller.CheckInventory(request) as JsonResult;
+
+            // Assert
+            Assert.NotNull(result);
+            dynamic data = result.Value;
+            
+            var shippingOptions = data.GetType().GetProperty("shipping_options").GetValue(data, null);
+            var firstOption = (shippingOptions as Array).GetValue(0);
+            decimal cost = (decimal)firstOption.GetType().GetProperty("cost").GetValue(firstOption, null);
+            string id = (string)firstOption.GetType().GetProperty("id").GetValue(firstOption, null);
+            
+            Assert.Equal(3.85m, cost);
+            Assert.Equal("standard_shipping", id);
+        }
+
+        [Fact]
+        public async Task AgentCheckout_ReturnsBadRequest_WhenAp2TokenIsMissing()
+        {
+            // Arrange
+            var sku = "TEST-3";
+            var request = new Nop.Plugin.Misc.UniversalCommerce.Controllers.Ap2CheckoutRequest(sku, 1, "test@test.com", null, new Nop.Plugin.Misc.UniversalCommerce.Controllers.Ap2Addr("John", "Doe", "123 Main St", "London", "W1", "GB"));
+            var product = new Product { Sku = sku };
+            
+            _productServiceMock.Setup(x => x.GetProductBySkuAsync(sku)).ReturnsAsync(product);
+
+            // Act
+            var result = await _controller.AgentCheckout(request) as BadRequestObjectResult;
+
+            // Assert
+            Assert.NotNull(result);
+            dynamic data = result.Value;
+            Assert.Equal("AP2 token required.", (string)data.GetType().GetProperty("error").GetValue(data, null));
+        }
+
+        [Fact]
+        public async Task AgentCheckout_PlacesOrderSuccessfully_WithCorrectShipping()
+        {
+            // Arrange
+            var sku = "TEST-4";
+            var request = new Nop.Plugin.Misc.UniversalCommerce.Controllers.Ap2CheckoutRequest(sku, 1, "test@test.com", "TOKEN_XYZ", new Nop.Plugin.Misc.UniversalCommerce.Controllers.Ap2Addr("John", "Doe", "123 Main St", "London", "W1", "GB"));
+            var product = new Product { Sku = sku, Price = 10.00m };
+            var customer = new Customer { Id = 1, Email = "test@test.com" };
+            var country = new Country { Id = 1, TwoLetterIsoCode = "GB" };
+            
+            _productServiceMock.Setup(x => x.GetProductBySkuAsync(sku)).ReturnsAsync(product);
+            _customerServiceMock.Setup(x => x.GetCustomerByEmailAsync(request.Email)).ReturnsAsync(customer);
+            _countryServiceMock.Setup(x => x.GetCountryByTwoLetterIsoCodeAsync(request.ShippingAddress.CountryTwoLetterIsoCode)).ReturnsAsync(country);
+            
+            // Mock PlaceOrder to succeed
+            var order = new Order { Id = 1234 };
+            var placeOrderResult = new PlaceOrderResult();
+            placeOrderResult.PlacedOrder = order;
+            _orderProcessingServiceMock.Setup(x => x.PlaceOrderAsync(It.IsAny<Nop.Services.Payments.ProcessPaymentRequest>()))
+                .ReturnsAsync(placeOrderResult)
+                .Callback<Nop.Services.Payments.ProcessPaymentRequest>(req => 
+                {
+                    // Assert total cost matches price + shipping (£10 + £3.85)
+                    Assert.Equal(13.85m, req.OrderTotal);
+                    Assert.Equal("TOKEN_XYZ", req.CustomValues["Ap2Token"]);
+                });
+
+            // Act
+            var result = await _controller.AgentCheckout(request) as OkObjectResult;
+
+            // Assert
+            Assert.NotNull(result);
+            dynamic data = result.Value;
+            Assert.True((bool)data.GetType().GetProperty("success").GetValue(data, null));
+            Assert.Equal(1234, (int)data.GetType().GetProperty("order_id").GetValue(data, null));
+            Assert.Equal(13.85m, (decimal)data.GetType().GetProperty("charged").GetValue(data, null));
+            
+            // Verify AddToCart was called
+            _shoppingCartServiceMock.Verify(x => x.AddToCartAsync(customer, product, ShoppingCartType.ShoppingCart, It.IsAny<int>(), It.IsAny<string>(), It.IsAny<decimal>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), request.Quantity, true), Times.Once);
+        }
+        [Fact]
+        public async Task CheckInventory_ReturnsAvailable_WhenInStock()
+        {
+            var sku = "INV-1";
+            var request = new UcpInventoryRequest { Sku = sku, Quantity = 1 };
+            var product = new Product { Sku = sku, Price = 10m, Published = true, ManageInventoryMethodId = 1, StockQuantity = 1 };
+            
+            _productServiceMock.Setup(x => x.GetProductBySkuAsync(sku)).ReturnsAsync(product);
+
+            var result = await _controller.CheckInventory(request) as JsonResult;
+            dynamic data = result.Value;
+            
+            Assert.True((bool)data.GetType().GetProperty("available").GetValue(data, null));
+        }
+
+        [Fact]
+        public async Task CheckInventory_ReturnsNotAvailable_WhenOutOfStock()
+        {
+            var sku = "INV-2";
+            var request = new UcpInventoryRequest { Sku = sku, Quantity = 2 };
+            var product = new Product { Sku = sku, Price = 10m, Published = true, ManageInventoryMethodId = 1, StockQuantity = 1 };
+            
+            _productServiceMock.Setup(x => x.GetProductBySkuAsync(sku)).ReturnsAsync(product);
+
+            var result = await _controller.CheckInventory(request) as JsonResult;
+            dynamic data = result.Value;
+            
+            Assert.False((bool)data.GetType().GetProperty("available").GetValue(data, null));
+        }
+
+        [Fact]
+        public async Task CheckInventory_ReturnsNotAvailable_WhenUnpublished()
+        {
+            var sku = "INV-3";
+            var request = new UcpInventoryRequest { Sku = sku, Quantity = 1 };
+            var product = new Product { Sku = sku, Price = 10m, Published = false, ManageInventoryMethodId = 1, StockQuantity = 10 };
+            
+            _productServiceMock.Setup(x => x.GetProductBySkuAsync(sku)).ReturnsAsync(product);
+
+            var result = await _controller.CheckInventory(request) as JsonResult;
+            dynamic data = result.Value;
+            
+            Assert.False((bool)data.GetType().GetProperty("available").GetValue(data, null));
+        }
+
+        [Fact]
+        public async Task CheckInventory_ReturnsAvailable_WhenTrackingDisabled()
+        {
+            var sku = "INV-4";
+            var request = new UcpInventoryRequest { Sku = sku, Quantity = 100 };
+            var product = new Product { Sku = sku, Price = 10m, Published = true, ManageInventoryMethodId = 0, StockQuantity = 0 };
+            
+            _productServiceMock.Setup(x => x.GetProductBySkuAsync(sku)).ReturnsAsync(product);
+
+            var result = await _controller.CheckInventory(request) as JsonResult;
+            dynamic data = result.Value;
+            
+            Assert.True((bool)data.GetType().GetProperty("available").GetValue(data, null));
+        }
+        [Fact]
+        public void GetManifest_ReturnsNotFound_WhenDisabled()
+        {
+            _ucpSettings.Enabled = false;
+
+            var result = _controller.GetManifest() as NotFoundObjectResult;
+
+            Assert.NotNull(result);
+            dynamic data = result.Value;
+            Assert.Equal("Agentic Commerce endpoints are currently disabled.", (string)data.GetType().GetProperty("error").GetValue(data, null));
+        }
+
+        [Fact]
+        public void GetManifest_ReturnsManifest_WhenEnabled()
+        {
+            _ucpSettings.Enabled = true;
+            _ucpSettings.ProtocolVersion = "1.0";
+            _ucpSettings.AllowAutonomousCheckout = true;
+
+            var result = _controller.GetManifest() as JsonResult;
+
+            Assert.NotNull(result);
+            dynamic data = result.Value;
+            Assert.Equal("1.0", (string)data.GetType().GetProperty("ucp_version").GetValue(data, null));
+            
+            var capabilities = data.GetType().GetProperty("capabilities").GetValue(data, null);
+            Assert.True((bool)capabilities.GetType().GetProperty("agent_checkout").GetValue(capabilities, null));
+            
+            Assert.Equal("*", _controller.Response.Headers["Access-Control-Allow-Origin"]);
+            Assert.Equal("public, max-age=86400", _controller.Response.Headers["Cache-Control"]);
+        }
+
+        [Fact]
+        public void UcpApiController_HasUcpAgentPolicyRateLimitingAttribute()
+        {
+            var type = typeof(UcpApiController);
+            var attribute = type.GetCustomAttributes(typeof(Microsoft.AspNetCore.RateLimiting.EnableRateLimitingAttribute), true)
+                .Cast<Microsoft.AspNetCore.RateLimiting.EnableRateLimitingAttribute>()
+                .FirstOrDefault();
+
+            Assert.NotNull(attribute);
+            Assert.Equal("UcpAgentPolicy", attribute.PolicyName);
+        }
+        [Fact]
+        public async Task CheckInventory_ReturnsNotFound_WhenSkuDoesNotExist()
+        {
+            var request = new UcpInventoryRequest { Sku = "INVALID", Quantity = 1 };
+            _productServiceMock.Setup(x => x.GetProductBySkuAsync("INVALID")).ReturnsAsync((Product)null);
+
+            var result = await _controller.CheckInventory(request) as NotFoundObjectResult;
+
+            Assert.NotNull(result);
+            dynamic data = result.Value;
+            Assert.Equal("SKU not found.", (string)data.GetType().GetProperty("error").GetValue(data, null));
+        }
+
+        [Fact]
+        public async Task AgentCheckout_ReturnsNotFound_WhenSkuDoesNotExist()
+        {
+            var request = new Nop.Plugin.Misc.UniversalCommerce.Controllers.Ap2CheckoutRequest("INVALID", 1, "test@test.com", "TOKEN", new Nop.Plugin.Misc.UniversalCommerce.Controllers.Ap2Addr("A", "B", "C", "D", "E", "F"));
+            _productServiceMock.Setup(x => x.GetProductBySkuAsync("INVALID")).ReturnsAsync((Product)null);
+
+            var result = await _controller.AgentCheckout(request) as NotFoundObjectResult;
+
+            Assert.NotNull(result);
+            dynamic data = result.Value;
+            Assert.Equal("SKU invalid.", (string)data.GetType().GetProperty("error").GetValue(data, null));
+        }
+
+        [Fact]
+        public async Task AgentCheckout_CreatesGuestCustomer_IfEmailNotFound()
+        {
+            var sku = "TEST-GUEST";
+            var request = new Nop.Plugin.Misc.UniversalCommerce.Controllers.Ap2CheckoutRequest(sku, 1, "guest@test.com", "TOKEN_XYZ", new Nop.Plugin.Misc.UniversalCommerce.Controllers.Ap2Addr("John", "Doe", "123", "City", "ZIP", "GB"));
+            var product = new Product { Sku = sku, Price = 10.00m };
+            var guestCustomer = new Customer { Id = 99 };
+            var country = new Country { Id = 1, TwoLetterIsoCode = "GB" };
+
+            _productServiceMock.Setup(x => x.GetProductBySkuAsync(sku)).ReturnsAsync(product);
+            _customerServiceMock.Setup(x => x.GetCustomerByEmailAsync("guest@test.com")).ReturnsAsync((Customer)null);
+            _customerServiceMock.Setup(x => x.InsertGuestCustomerAsync()).ReturnsAsync(guestCustomer);
+            _countryServiceMock.Setup(x => x.GetCountryByTwoLetterIsoCodeAsync("GB")).ReturnsAsync(country);
+
+            var placeOrderResult = new PlaceOrderResult { PlacedOrder = new Order { Id = 123 } };
+            _orderProcessingServiceMock.Setup(x => x.PlaceOrderAsync(It.IsAny<Nop.Services.Payments.ProcessPaymentRequest>())).ReturnsAsync(placeOrderResult);
+
+            var result = await _controller.AgentCheckout(request) as OkObjectResult;
+
+            Assert.NotNull(result);
+            _customerServiceMock.Verify(x => x.InsertGuestCustomerAsync(), Times.Once);
+            _customerServiceMock.Verify(x => x.UpdateCustomerAsync(guestCustomer), Times.Once);
+        }
+
+        [Fact]
+        public async Task AgentCheckout_ReturnsBadRequest_WhenOrderFails()
+        {
+            var sku = "TEST-FAIL";
+            var request = new Nop.Plugin.Misc.UniversalCommerce.Controllers.Ap2CheckoutRequest(sku, 1, "test@test.com", "TOKEN_XYZ", new Nop.Plugin.Misc.UniversalCommerce.Controllers.Ap2Addr("A", "B", "C", "D", "E", "F"));
+            var product = new Product { Sku = sku, Price = 10.00m };
+            var customer = new Customer { Id = 1, Email = "test@test.com" };
+
+            _productServiceMock.Setup(x => x.GetProductBySkuAsync(sku)).ReturnsAsync(product);
+            _customerServiceMock.Setup(x => x.GetCustomerByEmailAsync("test@test.com")).ReturnsAsync(customer);
+
+            var placeOrderResult = new PlaceOrderResult();
+            placeOrderResult.AddError("Payment declined");
+            _orderProcessingServiceMock.Setup(x => x.PlaceOrderAsync(It.IsAny<Nop.Services.Payments.ProcessPaymentRequest>())).ReturnsAsync(placeOrderResult);
+
+            var result = await _controller.AgentCheckout(request) as BadRequestObjectResult;
+
+            Assert.NotNull(result);
+            dynamic data = result.Value;
+            Assert.Equal("Order failed.", (string)data.GetType().GetProperty("error").GetValue(data, null));
+        }
+    }
+}

--- a/src/Tests/Nop.Plugin.Misc.UniversalCommerce.Tests/UnitTest1.cs
+++ b/src/Tests/Nop.Plugin.Misc.UniversalCommerce.Tests/UnitTest1.cs
@@ -1,0 +1,10 @@
+﻿namespace Nop.Plugin.Misc.UniversalCommerce.Tests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+
+    }
+}


### PR DESCRIPTION
Add UniversalCommerce plugin for Google AP2 integration

Introduced the `Misc.UniversalCommerce` plugin to integrate
Google Agentic Commerce (AP2) capabilities into nopCommerce.
The plugin enables agentic shopping, inventory checks, and
headless checkout functionality.

Key changes:
- Added `AgentUniversalPaymentProcessor` for AP2 payments.
- Implemented `UcpApiController` for agentic commerce APIs.
- Created `UcpAdminController` for admin configuration.
- Added `NopStartup` for service registration and rate-limiting.
- Defined models for AP2 requests, responses, and security.
- Updated solution and deployment files to include the plugin.
- Added unit tests for API endpoints and core functionality.