### PR TITLE
Add Vary header and improve canonical URL handling

### DIFF
--- a/src/Presentation/Nop.Web/Controllers/CommonController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CommonController.cs
@@ -185,6 +185,7 @@ public partial class CommonController : BasePublicController
     public virtual IActionResult PageNotFound()
     {
         Response.StatusCode = 404;
+        Response.Headers["Vary"] = "Accept";
 
         var acceptHeader = Request.Headers.Accept.ToString();
         if (acceptHeader.Contains("application/json") && !acceptHeader.Contains("text/html"))

--- a/src/Presentation/Nop.Web/Controllers/HomeController.cs
+++ b/src/Presentation/Nop.Web/Controllers/HomeController.cs
@@ -10,6 +10,7 @@ public partial class HomeController : BasePublicController
     [SaveLastContinueShoppingPage]
     public virtual IActionResult Index()
     {
+        Response.Headers["Vary"] = "Accept";
         var acceptHeaders = Request.GetTypedHeaders().Accept?.OrderByDescending(x => x.Quality ?? 1.0).ToList();
         if (acceptHeaders != null && acceptHeaders.Count > 0)
         {

--- a/src/Presentation/Nop.Web/Views/Home/Index.cshtml
+++ b/src/Presentation/Nop.Web/Views/Home/Index.cshtml
@@ -26,7 +26,7 @@
     NopHtml.AppendPageCssClassParts("html-home-page");
 
     //canonical
-    NopHtml.AddCanonicalUrlParts("https://www.rosecottagecroft.co.uk/");
+    NopHtml.AppendHeadCustomParts("<link rel=\"canonical\" href=\"https://www.rosecottagecroft.co.uk/\">");
 }
 <div class="page home-page">
     <div class="page-body">


### PR DESCRIPTION
Add Vary header and improve canonical URL handling

Added a `Vary` header with the value `Accept` to the `PageNotFound`
method in `CommonController.cs` and the `Index` method in
`HomeController.cs` to improve caching and content negotiation.

Updated canonical URL handling in `Index.cshtml` to use
`NopHtml.AppendHeadCustomParts` with an explicit `<link>` tag,
allowing greater flexibility in customizing the `<head>` section.