### PR TITLE
Update canonical URL handling for homepage

### DIFF
--- a/src/Presentation/Nop.Web/Views/Home/Index.cshtml
+++ b/src/Presentation/Nop.Web/Views/Home/Index.cshtml
@@ -24,9 +24,6 @@
 
     //page class
     NopHtml.AppendPageCssClassParts("html-home-page");
-
-    //canonical
-    NopHtml.AppendHeadCustomParts("<link rel=\"canonical\" href=\"https://www.rosecottagecroft.co.uk/\">");
 }
 <div class="page home-page">
     <div class="page-body">

--- a/src/Presentation/Nop.Web/Views/Shared/_Root.Head.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/_Root.Head.cshtml
@@ -92,7 +92,14 @@
     @NopHtml.GenerateCssFiles()
 
     @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.HeadHtmlTag })
-    @NopHtml.GenerateCanonicalUrls()
+    @if (Context.Request.Path.Value == "/" || string.IsNullOrEmpty(Context.Request.Path.Value))
+    {
+        <link rel="canonical" href="https://www.rosecottagecroft.co.uk/">
+    }
+    else
+    {
+        @NopHtml.GenerateCanonicalUrls()
+    }
     @await Component.InvokeAsync(typeof(BlogRssHeaderLinkViewComponent))
     @*Insert favicon and app icons head code*@
     @await Component.InvokeAsync(typeof(FaviconViewComponent))


### PR DESCRIPTION
Update canonical URL handling for homepage

Moved hardcoded canonical URL for the homepage from `Index.cshtml`
to `_Root.Head.cshtml` for centralized management. Added logic
to ensure the homepage always uses a consistent canonical URL,
while other pages continue to use dynamically generated canonical
URLs via `@NopHtml.GenerateCanonicalUrls()`.