### PR TITLE
Add AI Winback Email plugin with Azure OpenAI support

### DIFF
--- a/src/NopCommerce.sln
+++ b/src/NopCommerce.sln
@@ -113,6 +113,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nop.Plugin.Misc.UniversalCo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nop.Plugin.Misc.UniversalCommerce.Tests", "Tests\Nop.Plugin.Misc.UniversalCommerce.Tests\Nop.Plugin.Misc.UniversalCommerce.Tests.csproj", "{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nop.Plugin.Marketing.WinbackEmail", "Plugins\Nop.Plugin.Marketing.WinbackEmail\Nop.Plugin.Marketing.WinbackEmail.csproj", "{F5E187E6-5043-9D8A-9606-5656AA2D007C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -919,6 +921,22 @@ Global
 		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Release|x64.Build.0 = Release|Any CPU
 		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Release|x86.ActiveCfg = Release|Any CPU
 		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF}.Release|x86.Build.0 = Release|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Debug|x64.Build.0 = Debug|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Debug|x86.Build.0 = Debug|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Release|x64.ActiveCfg = Release|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Release|x64.Build.0 = Release|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Release|x86.ActiveCfg = Release|Any CPU
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -974,6 +992,7 @@ Global
 		{27E421E6-5630-D81D-5FB8-D4EF4A617A86} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 		{7FC7AEF7-2785-00E2-19BA-0CABAC9FE052} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 		{174CAB8C-D72D-4CD2-B61D-FDC7B94FDFDF} = {E8FC6874-E230-468A-9685-4747354B92FF}
+		{F5E187E6-5043-9D8A-9606-5656AA2D007C} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EE72A8B2-332A-4175-9319-6726D36E9D25}

--- a/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Controllers/WinbackEmailController.cs
+++ b/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Controllers/WinbackEmailController.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Nop.Plugin.Marketing.WinbackEmail.Models;
+using Nop.Plugin.Marketing.WinbackEmail.Services;
+using Nop.Services.Configuration;
+using Nop.Services.Messages;
+using Nop.Web.Framework;
+using Nop.Web.Framework.Controllers;
+using Nop.Web.Framework.Mvc.Filters;
+
+namespace Nop.Plugin.Marketing.WinbackEmail.Controllers;
+
+[AuthorizeAdmin]
+[Area(AreaNames.ADMIN)]
+[AutoValidateAntiforgeryToken]
+public class WinbackEmailController : BasePluginController
+{
+    private readonly WinbackEmailSettings _settings;
+    private readonly ISettingService _settingService;
+    private readonly INotificationService _notificationService;
+    private readonly WinbackEmailService _winbackEmailService;
+
+    public WinbackEmailController(
+        WinbackEmailSettings settings,
+        ISettingService settingService,
+        INotificationService notificationService,
+        WinbackEmailService winbackEmailService)
+    {
+        _settings = settings;
+        _settingService = settingService;
+        _notificationService = notificationService;
+        _winbackEmailService = winbackEmailService;
+    }
+
+    public IActionResult Configure()
+    {
+        var model = new ConfigurationModel
+        {
+            Enabled = _settings.Enabled,
+            StoreName = _settings.StoreName,
+            AzureOpenAIEndpoint = _settings.AzureOpenAIEndpoint,
+            AzureOpenAIApiKey = _settings.AzureOpenAIApiKey,
+            DeploymentName = _settings.DeploymentName,
+            FromEmail = _settings.FromEmail,
+            FromName = _settings.FromName,
+            Email1DaysLapsed = _settings.Email1DaysLapsed,
+            Email2DaysLapsed = _settings.Email2DaysLapsed,
+            Email3DaysLapsed = _settings.Email3DaysLapsed,
+            Email3DiscountCode = _settings.Email3DiscountCode
+        };
+
+        return View("~/Plugins/Marketing.WinbackEmail/Views/Configure.cshtml", model);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Configure(ConfigurationModel model)
+    {
+        if (!ModelState.IsValid)
+            return View("~/Plugins/Marketing.WinbackEmail/Views/Configure.cshtml", model);
+
+        _settings.Enabled = model.Enabled;
+        _settings.StoreName = model.StoreName;
+        _settings.AzureOpenAIEndpoint = model.AzureOpenAIEndpoint.Trim();
+        _settings.AzureOpenAIApiKey = model.AzureOpenAIApiKey.Trim();
+        _settings.DeploymentName = model.DeploymentName.Trim();
+        _settings.FromEmail = model.FromEmail.Trim();
+        _settings.FromName = model.FromName.Trim();
+        _settings.Email1DaysLapsed = model.Email1DaysLapsed;
+        _settings.Email2DaysLapsed = model.Email2DaysLapsed;
+        _settings.Email3DaysLapsed = model.Email3DaysLapsed;
+        _settings.Email3DiscountCode = model.Email3DiscountCode.Trim();
+
+        await _settingService.SaveSettingAsync(_settings);
+        _notificationService.SuccessNotification("Winback email settings saved.");
+
+        return RedirectToAction("Configure");
+    }
+
+    /// <summary>
+    /// Manually trigger the winback task from the admin UI for testing
+    /// </summary>
+    [HttpPost]
+    public async Task<IActionResult> RunNow()
+    {
+        await _winbackEmailService.ProcessWinbacksAsync();
+        _notificationService.SuccessNotification("Winback task executed — check the email queue for results.");
+        return RedirectToAction("Configure");
+    }
+}

--- a/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Infrastructure/NopStartup.cs
+++ b/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Infrastructure/NopStartup.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nop.Core.Infrastructure;
+using Nop.Plugin.Marketing.WinbackEmail.Services;
+
+namespace Nop.Plugin.Marketing.WinbackEmail.Infrastructure;
+
+public class NopStartup : INopStartup
+{
+    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddScoped<WinbackEmailGenerator>();
+        services.AddScoped<WinbackEmailService>();
+    }
+
+    public void Configure(IApplicationBuilder app) { }
+
+    public int Order => 100;
+}

--- a/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Models/ConfigurationModel.cs
+++ b/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Models/ConfigurationModel.cs
@@ -1,0 +1,40 @@
+﻿using Nop.Web.Framework.Models;
+using Nop.Web.Framework.Mvc.ModelBinding;
+
+namespace Nop.Plugin.Marketing.WinbackEmail.Models;
+
+public record ConfigurationModel : BaseNopModel
+{
+    [NopResourceDisplayName("Plugins.Marketing.WinbackEmail.Enabled")]
+    public bool Enabled { get; set; }
+
+    [NopResourceDisplayName("Plugins.Marketing.WinbackEmail.StoreName")]
+    public string StoreName { get; set; } = string.Empty;
+
+    [NopResourceDisplayName("Plugins.Marketing.WinbackEmail.AzureOpenAIEndpoint")]
+    public string AzureOpenAIEndpoint { get; set; } = string.Empty;
+
+    [NopResourceDisplayName("Plugins.Marketing.WinbackEmail.AzureOpenAIApiKey")]
+    public string AzureOpenAIApiKey { get; set; } = string.Empty;
+
+    [NopResourceDisplayName("Plugins.Marketing.WinbackEmail.DeploymentName")]
+    public string DeploymentName { get; set; } = "gpt-4o-mini";
+
+    [NopResourceDisplayName("Plugins.Marketing.WinbackEmail.FromEmail")]
+    public string FromEmail { get; set; } = string.Empty;
+
+    [NopResourceDisplayName("Plugins.Marketing.WinbackEmail.FromName")]
+    public string FromName { get; set; } = string.Empty;
+
+    [NopResourceDisplayName("Plugins.Marketing.WinbackEmail.Email1DaysLapsed")]
+    public int Email1DaysLapsed { get; set; } = 60;
+
+    [NopResourceDisplayName("Plugins.Marketing.WinbackEmail.Email2DaysLapsed")]
+    public int Email2DaysLapsed { get; set; } = 67;
+
+    [NopResourceDisplayName("Plugins.Marketing.WinbackEmail.Email3DaysLapsed")]
+    public int Email3DaysLapsed { get; set; } = 74;
+
+    [NopResourceDisplayName("Plugins.Marketing.WinbackEmail.Email3DiscountCode")]
+    public string Email3DiscountCode { get; set; } = string.Empty;
+}

--- a/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Models/WinbackCustomerContext.cs
+++ b/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Models/WinbackCustomerContext.cs
@@ -1,0 +1,28 @@
+﻿namespace Nop.Plugin.Marketing.WinbackEmail.Models;
+
+/// <summary>
+/// Everything Azure OpenAI needs to generate a personalised winback email
+/// </summary>
+public class WinbackCustomerContext
+{
+    public string CustomerFirstName { get; set; } = string.Empty;
+    public string CustomerEmail { get; set; } = string.Empty;
+    public int EmailNumber { get; set; } // 1, 2, or 3
+    public int DaysSinceLastOrder { get; set; }
+    public List<OrderSummary> RecentOrders { get; set; } = new();
+    public string? DiscountCode { get; set; }
+    public string StoreName { get; set; } = string.Empty;
+}
+
+public class OrderSummary
+{
+    public DateTime OrderDate { get; set; }
+    public decimal OrderTotal { get; set; }
+    public List<string> ProductNames { get; set; } = new();
+}
+
+public class GeneratedEmail
+{
+    public string Subject { get; set; } = string.Empty;
+    public string HtmlBody { get; set; } = string.Empty;
+}

--- a/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Nop.Plugin.Marketing.WinbackEmail.csproj
+++ b/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Nop.Plugin.Marketing.WinbackEmail.csproj
@@ -1,0 +1,58 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Copyright>Derrick Madden</Copyright>
+    <RootNamespace>Nop.Plugin.Marketing.WinbackEmail</RootNamespace>
+    <AssemblyName>Nop.Plugin.Marketing.WinbackEmail</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Copy plugin output to nopCommerce plugins folder on build -->
+    <OutputPath>..\..\Presentation\Nop.Web\Plugins\Marketing.WinbackEmail\</OutputPath>
+    <OutDir>$(OutputPath)</OutDir>
+    <!-- Copy NuGet references locally for dynamic loading -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.17" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.7.0" />
+    <ProjectReference Include="..\..\Presentation\Nop.Web.Framework\Nop.Web.Framework.csproj" />
+    <ProjectReference Include="..\..\Presentation\Nop.Web\Nop.Web.csproj" />
+    <ProjectReference Include="..\..\Libraries\Nop.Services\Nop.Services.csproj" />
+    <ProjectReference Include="..\..\Libraries\Nop.Data\Nop.Data.csproj" />
+    <ProjectReference Include="..\..\Libraries\Nop.Core\Nop.Core.csproj" />
+    <ClearPluginAssemblies Include="$(MSBuildProjectDirectory)\..\..\Build\ClearPluginAssemblies.proj" />
+  </ItemGroup>
+
+  <!-- Embed plugin.json and static assets -->
+  <ItemGroup>
+    <None Update="plugin.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="wwwroot\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <Content Include="Views\**\*.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <!--
+    Also copy wwwroot into Nop.Web/wwwroot/Plugins/Marketing.WinbackEmail/ at build time.
+    nopCommerce serves plugin static files from there, not from the plugin bin folder.
+    Without this, CSS/JS 404 even though the plugin loads fine.
+  -->
+  <Target Name="CopyPluginStaticFiles" AfterTargets="Build">
+    <ItemGroup>
+      <PluginStaticFiles Include="wwwroot\**\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(PluginStaticFiles)" DestinationFiles="@(PluginStaticFiles->'..\..\Presentation\Nop.Web\wwwroot\Plugins\Marketing.WinbackEmail\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- This target executes after "Build" target to clear redundant assemblies -->
+  <Target Name="NopTarget" AfterTargets="Build">
+    <MSBuild Projects="@(ClearPluginAssemblies)" Properties="PluginPath=$(OutDir)" Targets="NopClear" />
+  </Target>
+
+</Project>

--- a/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Services/WinbackEmailGenerator.cs
+++ b/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Services/WinbackEmailGenerator.cs
@@ -1,0 +1,128 @@
+﻿using System.Text.Json;
+using Azure;
+using Azure.AI.OpenAI;
+using Microsoft.Extensions.Logging;
+using Nop.Plugin.Marketing.WinbackEmail.Models;
+
+namespace Nop.Plugin.Marketing.WinbackEmail.Services;
+
+public class WinbackEmailGenerator
+{
+    private readonly WinbackEmailSettings _settings;
+    private readonly ILogger<WinbackEmailGenerator> _logger;
+
+    public WinbackEmailGenerator(
+        WinbackEmailSettings settings,
+        ILogger<WinbackEmailGenerator> logger)
+    {
+        _settings = settings;
+        _logger = logger;
+    }
+
+    public async Task<GeneratedEmail?> GenerateAsync(WinbackCustomerContext context)
+    {
+        try
+        {
+            var client = new OpenAIClient(
+                new Uri(_settings.AzureOpenAIEndpoint),
+                new AzureKeyCredential(_settings.AzureOpenAIApiKey)
+            );
+
+            var systemPrompt = BuildSystemPrompt();
+            var userPrompt = BuildUserPrompt(context);
+
+            var options = new ChatCompletionsOptions
+            {
+                DeploymentName = _settings.DeploymentName,
+                Messages =
+                {
+                    new ChatRequestSystemMessage(systemPrompt),
+                    new ChatRequestUserMessage(userPrompt)
+                },
+                MaxTokens = 800,
+                Temperature = 0.7f
+            };
+
+            var response = await client.GetChatCompletionsAsync(options);
+            var content = response.Value.Choices[0].Message.Content;
+
+            return ParseResponse(content);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate winback email for {Email}", context.CustomerEmail);
+            return null;
+        }
+    }
+
+    private static string BuildSystemPrompt() => """
+        You are an email copywriter for a small UK-based e-commerce store.
+        Write warm, personal, and genuine winback emails — never pushy or salesy.
+        Always respond with valid JSON in this exact format:
+        {
+          "subject": "email subject line here",
+          "htmlBody": "full html email body here"
+        }
+        The HTML body should be clean, simple, mobile-friendly HTML.
+        Use British English spelling throughout.
+        Do not include any text outside the JSON object.
+        """;
+
+    private static string BuildUserPrompt(WinbackCustomerContext context)
+    {
+        var orderHistory = context.RecentOrders.Any()
+            ? string.Join("\n", context.RecentOrders.Select(o =>
+                $"- {o.OrderDate:d MMM yyyy}: {string.Join(", ", o.ProductNames)} (£{o.OrderTotal:F2})"))
+            : "No order history available";
+
+        var emailAngle = context.EmailNumber switch
+        {
+            1 => "A warm, genuine 'we miss you' message. No discount. Just a personal, friendly check-in that reminds them of their positive experience with the store.",
+            2 => "Highlight what's new or popular in the store since their last visit. Make it feel like an insider update, not a promotional blast.",
+            3 => $"A final gentle nudge. Include the discount code '{context.DiscountCode}' if provided (only mention it if it's not empty). Keep it light — no pressure.",
+            _ => "A warm re-engagement message."
+        };
+
+        return $"""
+            Write winback email #{context.EmailNumber} of 3 for this customer:
+
+            Customer name: {context.CustomerFirstName}
+            Days since last order: {context.DaysSinceLastOrder}
+            Store name: {context.StoreName}
+            Discount code (email 3 only, may be empty): {context.DiscountCode ?? "none"}
+
+            Their order history:
+            {orderHistory}
+
+            Email angle: {emailAngle}
+
+            Keep the subject line under 50 characters.
+            Keep the body concise — 3 to 5 short paragraphs maximum.
+            Sign off warmly from the {context.StoreName} team.
+            """;
+    }
+
+    private static GeneratedEmail? ParseResponse(string content)
+    {
+        try
+        {
+            // Strip markdown code fences if present
+            var cleaned = content
+                .Replace("```json", "")
+                .Replace("```", "")
+                .Trim();
+
+            var result = JsonSerializer.Deserialize<JsonElement>(cleaned);
+
+            return new GeneratedEmail
+            {
+                Subject = result.GetProperty("subject").GetString() ?? string.Empty,
+                HtmlBody = result.GetProperty("htmlBody").GetString() ?? string.Empty
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Services/WinbackEmailService.cs
+++ b/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Services/WinbackEmailService.cs
@@ -1,0 +1,224 @@
+using Microsoft.Extensions.Logging;
+using Nop.Core;
+using Nop.Core.Domain.Messages;
+using Nop.Core.Domain.Orders;
+using Nop.Plugin.Marketing.WinbackEmail.Models;
+using Nop.Services.Catalog;
+using Nop.Services.Customers;
+using Nop.Services.Messages;
+using Nop.Services.Orders;
+
+namespace Nop.Plugin.Marketing.WinbackEmail.Services;
+
+public class WinbackEmailService
+{
+    private readonly WinbackEmailSettings _settings;
+    private readonly WinbackEmailGenerator _generator;
+    private readonly ICustomerService _customerService;
+    private readonly IOrderService _orderService;
+    private readonly IProductService _productService;
+    private readonly IEmailAccountService _emailAccountService;
+    private readonly IQueuedEmailService _queuedEmailService;
+    private readonly INewsLetterSubscriptionService _newsletterService;
+    private readonly IStoreContext _storeContext;
+    private readonly ILogger<WinbackEmailService> _logger;
+
+    public WinbackEmailService(
+        WinbackEmailSettings settings,
+        WinbackEmailGenerator generator,
+        ICustomerService customerService,
+        IOrderService orderService,
+        IProductService productService,
+        IEmailAccountService emailAccountService,
+        IQueuedEmailService queuedEmailService,
+        INewsLetterSubscriptionService newsletterService,
+        IStoreContext storeContext,
+        ILogger<WinbackEmailService> logger)
+    {
+        _settings = settings;
+        _generator = generator;
+        _customerService = customerService;
+        _orderService = orderService;
+        _productService = productService;
+        _emailAccountService = emailAccountService;
+        _queuedEmailService = queuedEmailService;
+        _newsletterService = newsletterService;
+        _storeContext = storeContext;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Called by the scheduled task — finds lapsed customers and queues winback emails
+    /// </summary>
+    public async Task ProcessWinbacksAsync()
+    {
+        if (!_settings.Enabled)
+            return;
+
+        var store = await _storeContext.GetCurrentStoreAsync();
+        var emailAccount = await GetEmailAccountAsync();
+
+        if (emailAccount == null)
+        {
+            _logger.LogWarning("Winback: No matching email account found for {FromEmail}", _settings.FromEmail);
+            return;
+        }
+
+        // Process each email in the sequence
+        await ProcessEmailStepAsync(emailAccount, store.Id, _settings.Email1DaysLapsed, 1);
+        await ProcessEmailStepAsync(emailAccount, store.Id, _settings.Email2DaysLapsed, 2);
+        await ProcessEmailStepAsync(emailAccount, store.Id, _settings.Email3DaysLapsed, 3);
+    }
+
+    private async Task ProcessEmailStepAsync(EmailAccount emailAccount, int storeId, int daysLapsed, int emailNumber)
+    {
+        var targetDate = DateTime.UtcNow.Date.AddDays(-daysLapsed);
+
+        // Find customers whose most recent order was exactly on targetDate
+        // and who are subscribed to marketing emails
+        var customers = await GetLapsedCustomersAsync(targetDate, storeId);
+
+        _logger.LogInformation("Winback email {EmailNumber}: found {Count} customers lapsed on {Date}",
+            emailNumber, customers.Count, targetDate.ToShortDateString());
+
+        foreach (var (customerId, customerEmail, firstName) in customers)
+        {
+            try
+            {
+                var context = await BuildContextAsync(customerId, customerEmail, firstName, emailNumber, daysLapsed);
+                var generated = await _generator.GenerateAsync(context);
+
+                if (generated == null)
+                {
+                    _logger.LogWarning("Winback: Failed to generate email for customer {CustomerId}", customerId);
+                    continue;
+                }
+
+                await QueueEmailAsync(emailAccount, customerEmail, firstName, generated);
+
+                _logger.LogInformation("Winback email {EmailNumber} queued for {Email}", emailNumber, customerEmail);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Winback: Error processing customer {CustomerId}", customerId);
+            }
+        }
+    }
+
+    private async Task<List<(int CustomerId, string Email, string FirstName)>> GetLapsedCustomersAsync(
+        DateTime lastOrderDate, int storeId)
+    {
+        var result = new List<(int, string, string)>();
+
+        // Get orders placed on the target date
+        var orders = await _orderService.SearchOrdersAsync(
+            storeId: storeId,
+            createdFromUtc: lastOrderDate,
+            createdToUtc: lastOrderDate.AddDays(1).AddSeconds(-1)
+        );
+
+        foreach (var order in orders)
+        {
+            // Check this is the customer's most recent order
+            var allOrders = await _orderService.SearchOrdersAsync(
+                customerId: order.CustomerId,
+                storeId: storeId
+            );
+
+            var mostRecent = allOrders.OrderByDescending(o => o.CreatedOnUtc).FirstOrDefault();
+            if (mostRecent?.Id != order.Id)
+                continue; // They've ordered since — skip
+
+            var customer = await _customerService.GetCustomerByIdAsync(order.CustomerId);
+            if (customer == null || customer.Deleted || !customer.Active)
+                continue;
+
+            // GDPR — only send to marketing opt-in customers
+            var subscriptions = await _newsletterService.GetNewsLetterSubscriptionsByEmailAsync(
+                customer.Email, storeId);
+            var subscription = subscriptions.FirstOrDefault();
+
+            if (subscription == null || subscription.Active == false)
+                continue;
+
+            var firstName = await _customerService.GetCustomerFullNameAsync(customer);
+            firstName = firstName?.Split(' ').FirstOrDefault() ?? "there";
+
+            result.Add((customer.Id, customer.Email, firstName));
+        }
+
+        return result;
+    }
+
+    private async Task<WinbackCustomerContext> BuildContextAsync(
+        int customerId, string email, string firstName, int emailNumber, int daysLapsed)
+    {
+        var orders = await _orderService.SearchOrdersAsync(customerId: customerId);
+        var recentOrders = orders
+            .OrderByDescending(o => o.CreatedOnUtc)
+            .Take(3)
+            .ToList();
+
+        var orderSummaries = new List<OrderSummary>();
+
+        foreach (var order in recentOrders)
+        {
+            var items = await _orderService.GetOrderItemsAsync(order.Id);
+            var productNames = new List<string>();
+
+            foreach (var item in items)
+            {
+                var product = await _productService.GetProductByIdAsync(item.ProductId);
+                if (product != null)
+                    productNames.Add(product.Name);
+            }
+
+            orderSummaries.Add(new OrderSummary
+            {
+                OrderDate = order.CreatedOnUtc,
+                OrderTotal = order.OrderTotal,
+                ProductNames = productNames
+            });
+        }
+
+        return new WinbackCustomerContext
+        {
+            CustomerFirstName = firstName,
+            CustomerEmail = email,
+            EmailNumber = emailNumber,
+            DaysSinceLastOrder = daysLapsed,
+            RecentOrders = orderSummaries,
+            DiscountCode = emailNumber == 3 ? _settings.Email3DiscountCode : null,
+            StoreName = _settings.StoreName
+        };
+    }
+
+    private async Task QueueEmailAsync(
+        EmailAccount emailAccount,
+        string toEmail,
+        string toName,
+        GeneratedEmail generated)
+    {
+        var queuedEmail = new QueuedEmail
+        {
+            Priority = QueuedEmailPriority.High,
+            From = _settings.FromEmail,
+            FromName = _settings.FromName,
+            To = toEmail,
+            ToName = toName,
+            Subject = generated.Subject,
+            Body = generated.HtmlBody,
+            CreatedOnUtc = DateTime.UtcNow,
+            EmailAccountId = emailAccount.Id
+        };
+
+        await _queuedEmailService.InsertQueuedEmailAsync(queuedEmail);
+    }
+
+    private async Task<EmailAccount?> GetEmailAccountAsync()
+    {
+        var accounts = await _emailAccountService.GetAllEmailAccountsAsync();
+        return accounts.FirstOrDefault(a =>
+            a.Email.Equals(_settings.FromEmail, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Tasks/WinbackEmailTask.cs
+++ b/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Tasks/WinbackEmailTask.cs
@@ -1,0 +1,23 @@
+﻿using Nop.Plugin.Marketing.WinbackEmail.Services;
+using Nop.Services.ScheduleTasks;
+
+namespace Nop.Plugin.Marketing.WinbackEmail.Tasks;
+
+/// <summary>
+/// Scheduled task — runs nightly and processes winback emails for all sequence steps.
+/// Register via nopCommerce admin: Configuration → Schedule Tasks
+/// </summary>
+public class WinbackEmailTask : IScheduleTask
+{
+    private readonly WinbackEmailService _winbackEmailService;
+
+    public WinbackEmailTask(WinbackEmailService winbackEmailService)
+    {
+        _winbackEmailService = winbackEmailService;
+    }
+
+    public async Task ExecuteAsync()
+    {
+        await _winbackEmailService.ProcessWinbacksAsync();
+    }
+}

--- a/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Views/Configure.cshtml
@@ -1,0 +1,51 @@
+@model Nop.Plugin.Misc.UniversalCommerce.Models.ConfigurationModel
+@{
+    Layout = "_ConfigurePlugin";
+}
+
+<form asp-controller="UcpAdmin" asp-action="Configure" method="post">
+    <div class="cards-group">
+        <div class="card card-default">
+            <div class="card-header">General Rules</div>
+            <div class="card-body">
+                <div class="form-group row">
+                    <div class="col-md-3"><nop-label asp-for="Enabled" /></div>
+                    <div class="col-md-9"><nop-editor asp-for="Enabled" /></div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-md-3"><nop-label asp-for="ProtocolVersion" /></div>
+                    <div class="col-md-9"><nop-editor asp-for="ProtocolVersion" /></div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-md-3"><nop-label asp-for="AllowAutonomousCheckout" /></div>
+                    <div class="col-md-9"><nop-editor asp-for="AllowAutonomousCheckout" /></div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card card-default">
+            <div class="card-header">Agent Rate Limiting Thresholds</div>
+            <div class="card-body">
+                <div class="form-group row">
+                    <div class="col-md-3"><nop-label asp-for="PermitLimit" /></div>
+                    <div class="col-md-9"><nop-editor asp-for="PermitLimit" /></div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-md-3"><nop-label asp-for="WindowInSeconds" /></div>
+                    <div class="col-md-9"><nop-editor asp-for="WindowInSeconds" /></div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-md-3"><nop-label asp-for="QueueLimit" /></div>
+                    <div class="col-md-9"><nop-editor asp-for="QueueLimit" /></div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-md-9 offset-md-3">
+                        <button type="submit" name="save" class="btn btn-primary">
+                            <i class="far fa-save"></i> Save Changes
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</form>

--- a/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Views/_ViewImports.cshtml
+++ b/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/Views/_ViewImports.cshtml
@@ -1,0 +1,14 @@
+@inherits Nop.Web.Framework.Mvc.Razor.NopRazorPage<TModel>
+
+@inject INopHtmlHelper NopHtml
+@inject INopUrlHelper NopUrl
+
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, Nop.Web.Framework
+
+@using Microsoft.AspNetCore.Mvc.ViewFeatures
+@using Nop.Web.Framework.Models
+@using Nop.Web.Framework.Models.DataTables
+@using Nop.Web.Framework.Mvc.Routing
+@using Nop.Web.Framework.UI
+@using Nop.Plugin.Misc.UniversalCommerce.Models

--- a/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/WinbackEmailPlugin.cs
+++ b/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/WinbackEmailPlugin.cs
@@ -1,0 +1,73 @@
+﻿using Nop.Core;
+using Nop.Core.Domain.ScheduleTasks;
+using Nop.Plugin.Marketing.WinbackEmail.Tasks;
+using Nop.Services.Configuration;
+using Nop.Services.Helpers;
+using Nop.Services.Localization;
+using Nop.Services.Plugins;
+using Nop.Services.ScheduleTasks;
+
+namespace Nop.Plugin.Marketing.WinbackEmail;
+
+public class WinbackEmailPlugin : BasePlugin
+{
+    private readonly ISettingService _settingService;
+    private readonly IScheduleTaskService _scheduleTaskService;
+    private readonly IWebHelper _webHelper;
+
+    public WinbackEmailPlugin(
+        ISettingService settingService,
+        IScheduleTaskService scheduleTaskService,
+        IWebHelper webHelper)
+    {
+        _settingService = settingService;
+        _scheduleTaskService = scheduleTaskService;
+        _webHelper = webHelper;
+    }
+
+    public override string GetConfigurationPageUrl()
+        => $"{_webHelper.GetStoreLocation()}Admin/WinbackEmail/Configure";
+
+    public override async Task InstallAsync()
+    {
+        await _settingService.SaveSettingAsync(new WinbackEmailSettings
+        {
+            Enabled = false,
+            DeploymentName = "gpt-4o-mini",
+            Email1DaysLapsed = 60,
+            Email2DaysLapsed = 67,
+            Email3DaysLapsed = 74
+        });
+
+        // Register the nightly scheduled task
+        var task = await _scheduleTaskService.GetTaskByTypeAsync(
+            typeof(WinbackEmailTask).FullName!);
+
+        if (task == null)
+        {
+            await _scheduleTaskService.InsertTaskAsync(new ScheduleTask
+            {
+                Name = "AI Winback Email",
+                Seconds = 86400, // 24 hours
+                Type = typeof(WinbackEmailTask).FullName!,
+                Enabled = false, // Enable manually once configured
+                StopOnError = false
+            });
+        }
+
+        await base.InstallAsync();
+    }
+
+    public override async Task UninstallAsync()
+    {
+        await _settingService.DeleteSettingAsync<WinbackEmailSettings>();
+
+        var task = await _scheduleTaskService.GetTaskByTypeAsync(
+            typeof(WinbackEmailTask).FullName!);
+
+        if (task != null)
+            await _scheduleTaskService.DeleteTaskAsync(task);
+
+        await base.UninstallAsync();
+    }
+}

--- a/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/WinbackEmailSettings.cs
+++ b/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/WinbackEmailSettings.cs
@@ -1,0 +1,61 @@
+﻿using Nop.Core.Configuration;
+
+namespace Nop.Plugin.Marketing.WinbackEmail;
+
+public class WinbackEmailSettings : ISettings
+{
+    /// <summary>
+    /// Whether the winback flow is active
+    /// </summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>
+    /// Azure OpenAI endpoint e.g. https://yourresource.openai.azure.com
+    /// </summary>
+    public string AzureOpenAIEndpoint { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Azure OpenAI API key
+    /// </summary>
+    public string AzureOpenAIApiKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Azure OpenAI deployment name e.g. gpt-4o-mini
+    /// </summary>
+    public string DeploymentName { get; set; } = "gpt-4o-mini";
+
+    /// <summary>
+    /// Your store name — used in email copy
+    /// </summary>
+    public string StoreName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Days since last order before email 1 is sent
+    /// </summary>
+    public int Email1DaysLapsed { get; set; } = 60;
+
+    /// <summary>
+    /// Days since last order before email 2 is sent
+    /// </summary>
+    public int Email2DaysLapsed { get; set; } = 67;
+
+    /// <summary>
+    /// Days since last order before email 3 is sent
+    /// </summary>
+    public int Email3DaysLapsed { get; set; } = 74;
+
+    /// <summary>
+    /// Optional discount code to include in email 3
+    /// </summary>
+    public string Email3DiscountCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Email address to send from — must match a nopCommerce email account
+    /// </summary>
+    public string FromEmail { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Display name for the from address
+    /// </summary>
+    public string FromName { get; set; } = string.Empty;
+}

--- a/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/plugin.json
+++ b/src/Plugins/Nop.Plugin.Marketing.WinbackEmail/plugin.json
@@ -1,0 +1,11 @@
+{
+  "Group": "Marketing",
+  "FriendlyName": "AI Winback Email",
+  "SystemName": "Marketing.WinbackEmail",
+  "Version": "1.0.0",
+  "SupportedVersions": [ "5.00" ],
+  "Author": "Derrick Madden",
+  "DisplayOrder": 1,
+  "FileName": "Nop.Plugin.Marketing.WinbackEmail.dll",
+  "Description": "Sends AI-personalised winback email sequences to lapsed customers using Azure OpenAI."
+}

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/AgentUniversalPaymentProcessor.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/AgentUniversalPaymentProcessor.cs
@@ -142,7 +142,7 @@ namespace Nop.Plugin.Misc.UniversalCommerce
 
         public Type GetPublicViewComponent()
         {
-            return null; // Headless integration, no UI rendered
+            return null!; // Headless integration, no UI rendered
         }
 
         #endregion

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/Ap2CheckoutModels.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/Ap2CheckoutModels.cs
@@ -1,4 +1,5 @@
-﻿public class Ap2CheckoutRequest
+#pragma warning disable CS8618
+public class Ap2CheckoutRequest
 {
     public string Sku { get; set; }
     public int Quantity { get; set; }

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/Ap2SecurityModels.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/Ap2SecurityModels.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS8618
 using System.Text.Json.Serialization;
 
 namespace Nop.Plugin.Misc.UniversalCommerce.Models

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/ConfigurationModel.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/ConfigurationModel.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS8618
 using Nop.Web.Framework.Models;
 using Nop.Web.Framework.Mvc.ModelBinding;
 

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/UcpCatalogModels.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Models/UcpCatalogModels.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+#pragma warning disable CS8618
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Nop.Plugin.Misc.UniversalCommerce.Models

--- a/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Services/Ap2SecurityService.cs
+++ b/src/Plugins/Nop.Plugin.Misc.UniversalCommerce/Services/Ap2SecurityService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
@@ -63,7 +63,7 @@ namespace Nop.Plugin.Misc.UniversalCommerce.Services
                         continue;
 
                     var keyValue = keyNode.GetProperty("keyValue").GetString();
-                    var publicKeyBytes = Convert.FromBase64String(keyValue);
+                    var publicKeyBytes = Convert.FromBase64String(keyValue!);
 
                     using var ecdsa = ECDsa.Create();
                     ecdsa.ImportSubjectPublicKeyInfo(publicKeyBytes, out _);

--- a/src/Plugins/Nop.Plugin.Widgets.ImagePuzzle/Services/PuzzlePriceCalculationService.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.ImagePuzzle/Services/PuzzlePriceCalculationService.cs
@@ -166,7 +166,7 @@ public partial class PuzzlePriceCalculationService : PriceCalculationService
             //System.IO.File.AppendAllText(logPath, logEntry);
             return finalDiscounts;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             //logEntry += $" [ERROR] {ex.Message}\n";
             //System.IO.File.AppendAllText(logPath, logEntry);

--- a/src/Plugins/Nop.Plugin.Widgets.SeoEnhancements/SeoEnhancementsPlugin.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.SeoEnhancements/SeoEnhancementsPlugin.cs
@@ -52,7 +52,7 @@ public class SeoEnhancementsPlugin : BasePlugin, IWidgetPlugin
         if (widgetZone.Equals("categorydetails_bottom", StringComparison.InvariantCultureIgnoreCase))
             return typeof(Components.SeoFaqViewComponent);
 
-        return null;
+        return null!;
     }
 
     public override string GetConfigurationPageUrl()

--- a/src/Plugins/Nop.Plugin.Widgets.ShoppableBanner/Models/ConfigurationModel.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.ShoppableBanner/Models/ConfigurationModel.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS8618
 using System.ComponentModel.DataAnnotations;
 using Nop.Web.Framework.Models;
 using Nop.Web.Framework.Mvc.ModelBinding;

--- a/src/Plugins/Nop.Plugin.Widgets.ShoppableBanner/Models/ShoppableBannerModel.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.ShoppableBanner/Models/ShoppableBannerModel.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS8618
 using System.Collections.Generic;
 using Nop.Web.Framework.Models;
 

--- a/src/Plugins/Nop.Plugin.Widgets.ShoppableBanner/Models/ShoppableBannerSettings.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.ShoppableBanner/Models/ShoppableBannerSettings.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS8618
 using Nop.Core.Configuration;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;


### PR DESCRIPTION
Add AI Winback Email plugin with Azure OpenAI support

Introduced a new plugin, "Nop.Plugin.Marketing.WinbackEmail," to send AI-personalized winback email sequences to lapsed customers using Azure OpenAI. Registered the plugin in the solution file and added all necessary components, including:

- `WinbackEmailPlugin` for installation/uninstallation.
- `WinbackEmailSettings` for configuration.
- `WinbackEmailController` for admin UI management.
- `WinbackEmailService` for processing winback emails.
- `WinbackEmailGenerator` for generating personalized email content.
- `WinbackEmailTask` for nightly scheduled execution.

Added Razor views for configuration, registered services in `NopStartup`, and ensured GDPR compliance by targeting only marketing-opted-in customers. Integrated Azure OpenAI for dynamic email generation and added logging for debugging. Updated existing files for nullability compliance and consistency.