### PR TITLE
Fix mobile cart layout for responsive design

### DIFF
--- a/src/Presentation/Nop.Web/Themes/TheSolidInspired/Content/css/custom_v2.css
+++ b/src/Presentation/Nop.Web/Themes/TheSolidInspired/Content/css/custom_v2.css
@@ -5313,3 +5313,14 @@ body {
 }
 
 .tab-pane img { max-width: 100%; height: auto; }
+
+/* Mobile Cart Fix */
+@media (max-width: 980px) {
+  .order-summary-content table.cart thead { display: none; }
+  .order-summary-content table.cart, .order-summary-content table.cart tbody, .order-summary-content table.cart tr, .order-summary-content table.cart td { display: block; width: 100%; }
+  .order-summary-content table.cart tr { margin-bottom: 20px; border: 1px solid #eee; border-radius: 8px; overflow: hidden; padding-bottom: 15px; }
+  .order-summary-content table.cart td { text-align: center; padding: 10px !important; border: none !important; }
+  .order-summary-content table.cart .product-picture { width: 100% !important; padding: 15px !important; }
+  .order-summary-content table.cart .product-picture img { width: auto; max-width: 120px; }
+  .order-summary-content table.cart td label.td-title { display: inline-block; font-weight: bold; margin-right: 10px; }
+}


### PR DESCRIPTION
Fix mobile cart layout for responsive design

Added CSS rules to improve the cart table's layout on screens with a max width of 980px. Changes include hiding the table header, converting table elements to block display, and enhancing spacing, borders, and alignment for better usability. Adjusted `.product-picture` and image styles for proper scaling. Improved label styling for readability.