### PR TITLE
Refactor to use strongly-typed PublicInfoModel

### DIFF
--- a/src/Plugins/Nop.Plugin.Widgets.GoogleTagManager/Components/WidgetsGoogleTagManagerViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.GoogleTagManager/Components/WidgetsGoogleTagManagerViewComponent.cs
@@ -19,7 +19,13 @@ namespace Nop.Plugin.Widgets.GoogleTagManager.Components
             if (string.IsNullOrEmpty(_googleTagManagerSettings.TrackingId))
                 return Content("");
 
-            return View("~/Plugins/Widgets.GoogleTagManager/Views/PublicInfo.cshtml", new { TrackingId = _googleTagManagerSettings.TrackingId, WidgetZone = widgetZone });
+            var model = new Nop.Plugin.Widgets.GoogleTagManager.Models.PublicInfoModel
+            {
+                TrackingId = _googleTagManagerSettings.TrackingId,
+                WidgetZone = widgetZone
+            };
+
+            return View("~/Plugins/Widgets.GoogleTagManager/Views/PublicInfo.cshtml", model);
         }
     }
 }

--- a/src/Plugins/Nop.Plugin.Widgets.GoogleTagManager/Models/PublicInfoModel.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.GoogleTagManager/Models/PublicInfoModel.cs
@@ -1,0 +1,10 @@
+using Nop.Web.Framework.Models;
+
+namespace Nop.Plugin.Widgets.GoogleTagManager.Models
+{
+    public record PublicInfoModel : BaseNopModel
+    {
+        public string TrackingId { get; set; }
+        public string WidgetZone { get; set; }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Widgets.GoogleTagManager/Views/PublicInfo.cshtml
+++ b/src/Plugins/Nop.Plugin.Widgets.GoogleTagManager/Views/PublicInfo.cshtml
@@ -1,3 +1,4 @@
+@model Nop.Plugin.Widgets.GoogleTagManager.Models.PublicInfoModel
 @using Nop.Web.Framework.UI
 @{
     var trackingId = Model.TrackingId;


### PR DESCRIPTION
Refactor to use strongly-typed PublicInfoModel

Updated WidgetsGoogleTagManagerViewComponent.cs to use a strongly-typed PublicInfoModel instead of an anonymous object for passing data to the view.

Modified PublicInfo.cshtml to work with the new strongly-typed model, adding the @model directive and accessing properties from the model.

Introduced a new PublicInfoModel class in the Nop.Plugin.Widgets.GoogleTagManager.Models namespace, inheriting from BaseNopModel, with properties for TrackingId and WidgetZone.

These changes improve code structure, maintainability, and type safety.