### PR TITLE
Add PictureId support to MarketLocation entity

### DIFF
--- a/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Controllers/MarketLocatorAdminController.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Controllers/MarketLocatorAdminController.cs
@@ -267,6 +267,7 @@ public class MarketLocatorAdminController : BasePluginController
         Frequency = e.Frequency,
         Published = e.Published,
         DisplayOrder = e.DisplayOrder,
+        PictureId = e.PictureId,
     };
 
     private static MarketLocation MapToEntity(MarketLocationModel m, MarketLocation e)
@@ -285,6 +286,7 @@ public class MarketLocatorAdminController : BasePluginController
         e.Frequency = m.Frequency;
         e.Published = m.Published;
         e.DisplayOrder = m.DisplayOrder;
+        e.PictureId = m.PictureId;
         return e;
     }
 }

--- a/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Data/AddPictureIdToMarketLocation.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Data/AddPictureIdToMarketLocation.cs
@@ -1,0 +1,30 @@
+using FluentMigrator;
+using Nop.Data.Migrations;
+using Nop.Plugin.Widgets.MarketLocator.Domain;
+
+namespace Nop.Plugin.Widgets.MarketLocator.Data;
+
+[NopSchemaMigration("2026-07-17 10:00:00", "Widgets.MarketLocator add PictureId raw SQL")]
+public class AddPictureIdToMarketLocation : Migration
+{
+    public override void Up()
+    {
+        // FluentMigrator's typical SQL execution
+        Execute.Sql(@"
+            IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('[MarketLocation]') AND name = 'PictureId')
+            BEGIN
+                ALTER TABLE [MarketLocation] ADD [PictureId] int NOT NULL DEFAULT 0;
+            END
+        ");
+    }
+
+    public override void Down()
+    {
+        Execute.Sql(@"
+            IF EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('[MarketLocation]') AND name = 'PictureId')
+            BEGIN
+                ALTER TABLE [MarketLocation] DROP COLUMN [PictureId];
+            END
+        ");
+    }
+}

--- a/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Domain/MarketLocation.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Domain/MarketLocation.cs
@@ -43,6 +43,9 @@ public class MarketLocation : BaseEntity
     /// <summary>Controls sidebar sort order.</summary>
     public int DisplayOrder { get; set; }
     
+    /// <summary>The ID of the picture representing the market.</summary>
+    public int PictureId { get; set; }
+
     /// <summary>A short description for social media posts and map popups.</summary>
     public string Description { get; set; } = string.Empty;
 

--- a/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Messaging/Consumers/MarketLocationEventConsumer.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Messaging/Consumers/MarketLocationEventConsumer.cs
@@ -18,6 +18,7 @@ public class MarketLocationEventConsumer :
     private readonly ILogger<MarketLocationEventConsumer> _logger;
     private readonly MarketLocatorSettings _settings;
     private readonly Nop.Core.Configuration.AppSettings _appSettings;
+    private readonly Nop.Services.Media.IPictureService _pictureService;
 
     private string QueueName
     {
@@ -35,13 +36,15 @@ public class MarketLocationEventConsumer :
         IMarketLocationService marketLocationService,
         ILogger<MarketLocationEventConsumer> logger,
         MarketLocatorSettings settings,
-        Nop.Core.Configuration.AppSettings appSettings)
+        Nop.Core.Configuration.AppSettings appSettings,
+        Nop.Services.Media.IPictureService pictureService)
     {
         _publisher = publishers.FirstOrDefault();
         _marketLocationService = marketLocationService;
         _logger = logger;
         _settings = settings;
         _appSettings = appSettings;
+        _pictureService = pictureService;
     }
 
     public async Task HandleEventAsync(EntityInsertedEvent<MarketLocation> eventMessage)
@@ -70,7 +73,7 @@ public class MarketLocationEventConsumer :
 
             try
             {
-                var schedules = BuildMessagesAndTimes(market, "Created");
+                var schedules = await BuildMessagesAndTimesAsync(market, "Created");
                 var sequenceNumbers = new List<long>();
 
                 foreach (var (message, scheduledTime) in schedules)
@@ -130,7 +133,7 @@ public class MarketLocationEventConsumer :
                 await TryCancelPendingAsync(market, saveToDb: false);
 
                 // Re-schedule with the (potentially new) dates
-                var schedules = BuildMessagesAndTimes(market, "Updated");
+                var schedules = await BuildMessagesAndTimesAsync(market, "Updated");
                 var sequenceNumbers = new List<long>();
 
                 foreach (var (message, scheduledTime) in schedules)
@@ -230,7 +233,7 @@ public class MarketLocationEventConsumer :
         return true;
     }
 
-    private List<(MarketEventMessage message, DateTimeOffset? scheduledTime)> BuildMessagesAndTimes(
+    private async Task<List<(MarketEventMessage message, DateTimeOffset? scheduledTime)>> BuildMessagesAndTimesAsync(
         MarketLocation market, string changeType)
     {
         var occurrences = MarketDateHelper.GetAllFutureMarketOccurrences(market.UpcomingDates, market.Hours);
@@ -251,6 +254,15 @@ public class MarketLocationEventConsumer :
                 Description = market.Description,
                 MapUrl = $"{_settings.StoreUrl.TrimEnd('/')}/market-locations?id={market.Id}"
             };
+
+            if (market.PictureId > 0)
+            {
+                var pictureUrl = await _pictureService.GetPictureUrlAsync(market.PictureId);
+                if (!string.IsNullOrEmpty(pictureUrl))
+                {
+                    message.ImageUrl = pictureUrl;
+                }
+            }
 
             results.Add((message, scheduledTime));
         }

--- a/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Messaging/Messages/MarketEventMessage.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Messaging/Messages/MarketEventMessage.cs
@@ -9,5 +9,6 @@ namespace Nop.Plugin.Widgets.MarketLocator.Messaging.Messages
         public DateTime? EndDate { get; set; }
         public string? Description { get; set; }
         public string MapUrl { get; set; } = string.Empty;
+        public string? ImageUrl { get; set; }
     }
 }

--- a/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Models/Models.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Models/Models.cs
@@ -52,6 +52,10 @@ public record MarketLocationModel : BaseNopEntityModel
     [NopResourceDisplayName("Plugins.Widgets.MarketLocator.Fields.DisplayOrder")]
     public int DisplayOrder { get; set; }
 
+    [NopResourceDisplayName("Plugins.Widgets.MarketLocator.Fields.Picture")]
+    [UIHint("Picture")]
+    public int PictureId { get; set; }
+
     public IList<SelectListItem> AvailableFrequencies { get; set; } = new List<SelectListItem>
     {
         new("Weekly",     "Weekly"),

--- a/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Views/Admin/CreateOrEdit.cshtml
+++ b/src/Plugins/Nop.Plugin.Widgets.MarketLocator/Views/Admin/CreateOrEdit.cshtml
@@ -105,6 +105,11 @@
                             <div class="col-md-7"><nop-editor asp-for="Published" /></div>
                         </div>
 
+                        <div class="form-group row">
+                            <div class="col-md-5"><nop-label asp-for="PictureId" /></div>
+                            <div class="col-md-7"><nop-editor asp-for="PictureId" /></div>
+                        </div>
+
                         <div class="alert alert-info small mt-3">
                             <i class="fas fa-info-circle"></i>
                             <strong>Finding coordinates:</strong><br />


### PR DESCRIPTION
Add PictureId support to MarketLocation entity

Added a new `PictureId` property to the `MarketLocation` entity, model, and database schema to support associating a picture with a market. Updated `MarketLocatorAdminController` to handle `PictureId` during entity-model mapping.

Modified `MarketLocationEventConsumer` to inject `IPictureService` and fetch picture URLs asynchronously for scheduled messages. Extended `MarketEventMessage` to include an `ImageUrl` property.

Updated the `CreateOrEdit.cshtml` view to include a form field for `PictureId`. Added a FluentMigrator migration to add the `PictureId` column to the database.