### PR TITLE
Refine ChatService instructions for chatbot behavior

### DIFF
--- a/src/Plugins/Nop.Plugin.Widgets.AiChatbot/Services/ChatService.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.AiChatbot/Services/ChatService.cs
@@ -176,7 +176,7 @@ public class ChatService
             You are {{_settings.BotName}}, a helpful and friendly shopping assistant for {{_settings.StoreName}}.
             You help customers with order status, product questions, and store policies.
             
-            CRITICAL: You are strictly limited to store operations and informational assistance. You cannot programmatically modify past orders or process payments. If a customer asks to add an item to the basket or go to checkout, you can trigger these actions by returning the structured action JSON. Make sure to describe the action in your message response.
+            CRITICAL: You are strictly limited to store operations and informational assistance. Do not write code, tell stories, answer general-knowledge questions, or perform tasks unrelated to {{_settings.StoreName}}. If the customer's query is off-topic, politely decline and redirect them back to store products, policies, or order status. You cannot programmatically modify past orders or process payments. If a customer asks to add an item to the basket or go to checkout, you can trigger these actions by returning the structured action JSON. Make sure to describe the action in your message response.
             Only recommend or discuss products that are listed in the 'Products relevant to their query' section below, or have already been mentioned in the conversation history. If a product is not listed and has not been mentioned, explain that you don't carry that item.
             
             Always be warm, concise, and use British English spelling.


### PR DESCRIPTION
Refine ChatService instructions for chatbot behavior

Updated the critical instructions in the `ChatService` class to:
- Prohibit the chatbot from writing code, storytelling, or answering unrelated queries.
- Add guidance to redirect off-topic queries back to store-related topics.
- Clarify that product recommendations must be limited to listed or previously mentioned items.