### PR TITLE
Restrict VaultInstruction creation for payment tokens

### DIFF
--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Services/PayPalCommerceServiceManager.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Services/PayPalCommerceServiceManager.cs
@@ -1704,8 +1704,8 @@ public class PayPalCommerceServiceManager
                 var context = PrepareOrderContext(settings, details, paymentRequest.OrderGuid.ToString(), isApplepay);
                 var payer = await PrepareBillingDetailsAsync(settings, details);
 
-                //only registered customers can save payment tokens
-                var vault = !settings.UseVault || isGuest ? null : new VaultInstruction
+                //only registered customers can save payment tokens if saveCard is requested or recurring item
+                var vault = !settings.UseVault || isGuest || (!saveCard && !isRecurring) ? null : new VaultInstruction
                 {
                     UsageType = VaultUsageType.MERCHANT.ToString().ToUpper(),
                     CustomerType = VaultUsageType.CONSUMER.ToString().ToUpper(),


### PR DESCRIPTION
Restrict VaultInstruction creation for payment tokens

Updated logic to only create VaultInstruction if the user is a registered customer and either requested to save the card or the order contains a recurring item. If neither condition is met, VaultInstruction is set to null to prevent token storage.