### PR TITLE
Track checkout abandonment with Clarity event script

### DIFF
--- a/src/Presentation/Nop.Web/Views/Shared/_Root.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/_Root.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     Layout = "_Root.Head";
 }
 @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.BodyStartHtmlTagAfter })
@@ -26,3 +26,25 @@
 </div>
 @await Component.InvokeAsync(typeof(EuCookieLawViewComponent))
 @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.BodyEndHtmlTagBefore })
+
+<script asp-location="Footer">
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        var cartHasItems = document.querySelector('.cart-item-row') || document.querySelector('.checkout-data');
+        if (!cartHasItems) return;
+
+        var isSubmittingOrder = false;
+        document.addEventListener('submit', function () { isSubmittingOrder = true; });
+
+        function handleAbandonment() {
+            if (!isSubmittingOrder && document.visibilityState === 'hidden' && typeof clarity === 'function') {
+                clarity('event', 'checkout_left_page');
+            }
+        }
+
+        document.addEventListener('visibilitychange', handleAbandonment);
+        window.addEventListener('pagehide', handleAbandonment);
+    });
+})();
+</script>
+


### PR DESCRIPTION
Track checkout abandonment with Clarity event script

Added a script to _Root.cshtml that detects when users leave the checkout page with items in their cart without submitting an order. The script listens for visibility and page hide events, triggering a 'checkout_left_page' Clarity event to monitor checkout abandonment. No other functional changes were made.