### PR TITLE
Update market URL handling and chat navigation logic

### DIFF
--- a/src/Plugins/Nop.Plugin.Widgets.AiChatbot/Services/ChatService.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.AiChatbot/Services/ChatService.cs
@@ -320,7 +320,8 @@ public class ChatService
               * If asked about a specific town or city (e.g. Thurso, Lairg, Wick, etc.), filter by that town/city name and provide the upcoming dates, operating hours, and address for that market.
               * If asked for the next market, identify the earliest upcoming market date relative to today's date and report the market name, town/city, date, and hours.
               * Always inform customers asking about markets, delivery, or pickup options that they can select 'Market Pickup' during checkout (at the shipping step) to collect their order in person at any upcoming market for free without paying shipping fees!
-              * Direct customers to /marketlocator if they wish to view the full interactive map, and include a navigate action: { "type": "navigate", "url": "/marketlocator", "label": "Market Locator Map" }.
+              * When mentioning a specific market, link directly to its specific URL: /market-locations?id=ID (or /market-locations for all markets).
+              * CRITICAL: Do NOT return an automatic navigate action for general informational market questions. Only return a navigate action if the user explicitly asks to be taken to the page (e.g. "take me to the map" or "open the market page").
             - If the customer asks to add one or MULTIPLE items to their basket, include an addToCart action for EACH requested item in the "actions" array so all requested items are added to their basket at once in a single turn! State in your message response that you have added all requested items (e.g. "Done — I've added Slainte Mhath candle and Rosemary & Nettle shampoo bar to your basket.").
             - Only trigger navigation if the customer explicitly asks to go somewhere. Since this action is executed automatically in the background, write your message stating that you are redirecting them (e.g., "Sure, I'm opening your cart/checkout for you now.").
             - The shopping cart context is always the exact, real-time, up-to-date state of the user's basket (which already reflects all items added in previous turns). Do not perform manual calculations, additions, or adjustments to the basket total or items. Always trust and report the exact items and total value provided in the current context.
@@ -411,7 +412,7 @@ public class ChatService
                 ? string.Join(", ", m.Dates)
                 : "Dates vary — see market locator page";
 
-            sb.AppendLine($"- {m.Name} ({m.City}) — Address: {m.Address} — Operating Hours: {m.Hours} — Upcoming Dates: {datesText} — Frequency: {m.Frequency}");
+            sb.AppendLine($"- ID: {m.Id} — {m.Name} ({m.City}) — Address: {m.Address} — Operating Hours: {m.Hours} — Upcoming Dates: {datesText} — Market URL: /market-locations?id={m.Id}");
         }
 
         return sb.ToString();

--- a/src/Plugins/Nop.Plugin.Widgets.AiChatbot/Views/ChatWidget.cshtml
+++ b/src/Plugins/Nop.Plugin.Widgets.AiChatbot/Views/ChatWidget.cshtml
@@ -800,15 +800,18 @@
             .replace(/"/g, '&quot;')
             .replace(/'/g, '&#039;');
 
+        // Correct legacy /marketlocator paths to /market-locations
+        safe = safe.replace(/\/marketlocator/g, '/market-locations');
+
         // Format HTTP/HTTPS URLs
         safe = safe.replace(/(https?:\/\/[^\s<]+)/g, function(url) {
             return `<a href="${url}" target="_blank" rel="noopener noreferrer" class="ai-chat-link">${url}</a>`;
         });
 
-        // Format relative paths starting with / (e.g. /marketlocator, /cart, /checkout, /contactus)
+        // Format relative paths starting with / (e.g. /market-locations?id=5, /cart, /checkout, /contactus)
         safe = safe.replace(/(^|\s|[\(\[\{])(\/([a-zA-Z0-9_\-\/\?=&%]+))/g, function(match, prefix, path) {
             let label = path;
-            if (path === '/marketlocator') label = 'Market Locator Map 🗺️';
+            if (path.startsWith('/market-locations')) label = 'Market Locator Map 🗺️';
             else if (path === '/cart') label = 'View Cart 🛒';
             else if (path === '/checkout') label = 'Checkout 💳';
             else if (path === '/contactus') label = 'Contact Us 📬';
@@ -817,6 +820,17 @@
 
         return safe;
     }
+
+    // Handle clicks on inline links to close chat before navigating
+    messagesEl.addEventListener('click', (e) => {
+        const link = e.target.closest('a.ai-chat-link');
+        if (link && link.getAttribute('href')) {
+            const href = link.getAttribute('href');
+            if (!href.startsWith('http')) {
+                try { sessionStorage.setItem('ai_chat_open', 'false'); } catch (err) {}
+            }
+        }
+    });
 
     function appendBotMessage(text, actions) {
         const wrapper = document.createElement('div');
@@ -873,7 +887,7 @@
         switch (action.type) {
             case 'addToCart': return action.label ? `Add "${action.label}" to cart` : 'Add to cart';
             case 'navigate':
-                if (action.url === '/marketlocator') return '🗺️ Open Market Locator Map';
+                if (action.url && action.url.includes('market')) return '🗺️ Open Market Locator Map';
                 if (action.url === '/cart') return '🛒 View Cart';
                 if (action.url && action.url.includes('checkout')) return '💳 Go to Checkout';
                 return action.label ? `Go to ${action.label}` : 'Open Page';
@@ -906,7 +920,9 @@
                 return await addToCart(action.productId, action.quantity || 1);
             case 'navigate':
                 if (action.url) {
-                    window.location.href = action.url;
+                    let navUrl = action.url === '/marketlocator' ? '/market-locations' : action.url;
+                    try { sessionStorage.setItem('ai_chat_open', 'false'); } catch (e) {}
+                    window.location.href = navUrl;
                     return { ok: true, navigate: true };
                 }
                 return { ok: false, message: 'No URL provided.' };


### PR DESCRIPTION
Update market URL handling and chat navigation logic

Clarified ChatService instructions to link directly to /market-locations with market IDs, avoiding auto-navigation unless requested. Updated ChatWidget.cshtml to rewrite legacy /marketlocator paths, adjust link labeling, handle inline link clicks by closing chat before navigation, and ensure navigation actions use the new URL pattern.