### PR TITLE
Add Checkout Abandonment Tracker plugin

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -102,7 +102,8 @@ jobs:
             { "SystemName": "Widgets.AiRecommendations","Version": "1.00"},
             { "SystemName": "Widgets.AiChatbot","Version": "1.00"},
             { "SystemName": "ExternalAuth.Google","Version": "5.00.4"},
-            { "SystemName": "ExternalAuth.Apple","Version": "5.00.4"}
+            { "SystemName": "ExternalAuth.Apple","Version": "5.00.4"},
+            { "SystemName": "Misc.CheckoutAbandonmentTracker","Version": "1.00"}
           ],
           "PluginNamesToUninstall": [],
           "PluginNamesToDelete": [],

--- a/src/NopCommerce.sln
+++ b/src/NopCommerce.sln
@@ -125,6 +125,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nop.Plugin.ExternalAuth.Goo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nop.Plugin.ExternalAuth.Apple", "Plugins\Nop.Plugin.ExternalAuth.Apple\Nop.Plugin.ExternalAuth.Apple.csproj", "{1ECD911F-1AA3-44DC-B99C-27CAF637E522}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nop.Plugin.Misc.CheckoutAbandonmentTracker", "Plugins\Nop.Plugin.Misc.CheckoutAbandonmentTracker\Nop.Plugin.Misc.CheckoutAbandonmentTracker.csproj", "{191C8666-9A6D-5EA1-5F92-0E50D5623015}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1027,6 +1029,22 @@ Global
 		{1ECD911F-1AA3-44DC-B99C-27CAF637E522}.Release|x64.Build.0 = Release|Any CPU
 		{1ECD911F-1AA3-44DC-B99C-27CAF637E522}.Release|x86.ActiveCfg = Release|Any CPU
 		{1ECD911F-1AA3-44DC-B99C-27CAF637E522}.Release|x86.Build.0 = Release|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Debug|x64.Build.0 = Debug|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Debug|x86.Build.0 = Debug|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Release|Any CPU.Build.0 = Release|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Release|x64.ActiveCfg = Release|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Release|x64.Build.0 = Release|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Release|x86.ActiveCfg = Release|Any CPU
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1088,6 +1106,7 @@ Global
 		{7F863C04-08A0-7AB4-55C0-9B314E76510A} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 		{529797D5-7C7B-4981-B971-8B28C29C4C50} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 		{1ECD911F-1AA3-44DC-B99C-27CAF637E522} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
+		{191C8666-9A6D-5EA1-5F92-0E50D5623015} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EE72A8B2-332A-4175-9319-6726D36E9D25}

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/CheckoutAbandonmentTrackerPlugin.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/CheckoutAbandonmentTrackerPlugin.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Routing;
+using Nop.Core;
+using Nop.Core.Domain.ScheduleTasks;
+using Nop.Data.Migrations;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Services;
+using Nop.Services.Cms;
+using Nop.Services.Common;
+using Nop.Services.Helpers;
+using Nop.Services.Plugins;
+using Nop.Services.ScheduleTasks;
+using Nop.Services.Security;
+using Nop.Web.Framework.Menu;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker
+{
+    public class CheckoutAbandonmentTrackerPlugin : BasePlugin, IMiscPlugin, IAdminMenuPlugin
+    {
+        private readonly IMigrationManager _migrationManager;
+        private readonly IScheduleTaskService _scheduleTaskService;
+        private readonly IPermissionService _permissionService;
+        private readonly IWebHelper _webHelper;
+
+        private const string AbandonedCheckoutTaskType =
+            "Nop.Plugin.Misc.CheckoutAbandonmentTracker.Services.AbandonedCheckoutTask, Nop.Plugin.Misc.CheckoutAbandonmentTracker";
+
+        public CheckoutAbandonmentTrackerPlugin(
+            IMigrationManager migrationManager,
+            IScheduleTaskService scheduleTaskService,
+            IPermissionService permissionService,
+            IWebHelper webHelper)
+        {
+            _migrationManager = migrationManager;
+            _scheduleTaskService = scheduleTaskService;
+            _permissionService = permissionService;
+            _webHelper = webHelper;
+        }
+
+        public override string GetConfigurationPageUrl()
+        {
+            return $"{_webHelper.GetStoreLocation()}Admin/CheckoutAbandonmentTracker/List";
+        }
+
+        public override async Task InstallAsync()
+        {
+            // Creates the CheckoutAttempt table via CheckoutAttemptBuilder
+            _migrationManager.ApplyUpMigrations(GetType().Assembly);
+
+            // Register the scheduled task programmatically so it's active
+            // immediately on install, not just when an admin manually adds it.
+            if (await _scheduleTaskService.GetTaskByTypeAsync(AbandonedCheckoutTaskType) == null)
+            {
+                await _scheduleTaskService.InsertTaskAsync(new ScheduleTask
+                {
+                    Name = "Flag abandoned checkouts",
+                    Seconds = 1800, // 30 minutes
+                    Type = AbandonedCheckoutTaskType,
+                    Enabled = true,
+                    StopOnError = false
+                });
+            }
+
+            await base.InstallAsync();
+        }
+
+        public override async Task UninstallAsync()
+        {
+            var task = await _scheduleTaskService.GetTaskByTypeAsync(AbandonedCheckoutTaskType);
+            if (task != null)
+                await _scheduleTaskService.DeleteTaskAsync(task);
+
+            // Deliberately NOT dropping the CheckoutAttempt table (see
+            // SchemaMigration.Down and README) so re-enabling the plugin
+            // later doesn't lose historical abandonment data.
+            await base.UninstallAsync();
+        }
+
+        public async Task ManageSiteMapAsync(AdminMenuItem rootNode)
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermission.Configuration.MANAGE_PLUGINS))
+                return;
+
+            var pluginNode = new AdminMenuItem
+            {
+                SystemName = "Misc.CheckoutAbandonmentTracker",
+                Title = "Abandoned Checkouts",
+                Url = "/Admin/CheckoutAbandonmentTracker/List",
+                IconClass = "far fa-dot-circle",
+                Visible = true
+            };
+            rootNode.ChildNodes.Add(pluginNode);
+        }
+    }
+}
+
+
+

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Controllers/CheckoutAbandonmentTrackerController.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Controllers/CheckoutAbandonmentTrackerController.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Nop.Core;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Models;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Services;
+using Nop.Services.Customers;
+using Nop.Services.Security;
+using Nop.Web.Framework;
+using Nop.Web.Framework.Controllers;
+using Nop.Web.Framework.Models.Extensions;
+using Nop.Web.Framework.Mvc.Filters;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker.Controllers
+{
+    [Area(AreaNames.ADMIN)]
+    [AuthorizeAdmin]
+    [AutoValidateAntiforgeryToken]
+    public class CheckoutAbandonmentTrackerController : BasePluginController
+    {
+        private readonly ICheckoutAttemptService _checkoutAttemptService;
+        private readonly ICustomerService _customerService;
+        private readonly IStoreContext _storeContext;
+        private readonly IPermissionService _permissionService;
+
+        public CheckoutAbandonmentTrackerController(
+            ICheckoutAttemptService checkoutAttemptService,
+            ICustomerService customerService,
+            IStoreContext storeContext,
+            IPermissionService permissionService)
+        {
+            _checkoutAttemptService = checkoutAttemptService;
+            _customerService = customerService;
+            _storeContext = storeContext;
+            _permissionService = permissionService;
+        }
+
+        public async Task<IActionResult> List()
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermission.Configuration.MANAGE_PLUGINS))
+                return AccessDeniedView();
+
+            return View("~/Plugins/Misc.CheckoutAbandonmentTracker/Views/List.cshtml", new CheckoutAttemptSearchModel());
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> ListData(CheckoutAttemptSearchModel searchModel)
+        {
+            if (!await _permissionService.AuthorizeAsync(StandardPermission.Configuration.MANAGE_PLUGINS))
+                return await AccessDeniedJsonAsync();
+
+            var store = await _storeContext.GetCurrentStoreAsync();
+
+            var attempts = await _checkoutAttemptService.GetAbandonedAttemptsAsync(
+                store.Id,
+                searchModel.Page - 1,
+                searchModel.PageSize);
+
+            var model = await new CheckoutAttemptListModel().PrepareToGridAsync(searchModel, attempts, () =>
+            {
+                return attempts.SelectAwait(async attempt =>
+                {
+                    var customer = attempt.CustomerId.HasValue
+                        ? await _customerService.GetCustomerByIdAsync(attempt.CustomerId.Value)
+                        : null;
+
+                    var isGuest = customer == null || !await _customerService.IsRegisteredAsync(customer);
+
+                    return new CheckoutAttemptModel
+                    {
+                        Id = attempt.Id,
+                        CustomerEmail = isGuest ? "(guest)" : customer?.Email,
+                        CustomerGuid = attempt.CustomerGuid,
+                        LastStepReached = attempt.LastStepReached.ToString(),
+                        StartedOnUtc = attempt.StartedOnUtc,
+                        LastActivityUtc = attempt.LastActivityUtc,
+                        CartTotal = attempt.CartTotal,
+                        IsAbandoned = attempt.IsAbandoned,
+                        OrderId = attempt.OrderId
+                    };
+                });
+            });
+
+            return Json(model);
+        }
+    }
+}
+
+

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Controllers/CheckoutTrackingController.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Controllers/CheckoutTrackingController.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Nop.Core;
+using Nop.Core.Domain.Orders;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Domain;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Models;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Services;
+using Nop.Services.Orders;
+using Nop.Web.Framework.Controllers;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker.Controllers
+{
+    public class CheckoutTrackingController : BasePluginController
+    {
+        private readonly ICheckoutAttemptService _checkoutAttemptService;
+        private readonly IWorkContext _workContext;
+        private readonly IStoreContext _storeContext;
+        private readonly IShoppingCartService _shoppingCartService;
+        private readonly IOrderTotalCalculationService _orderTotalCalculationService;
+
+        public CheckoutTrackingController(
+            ICheckoutAttemptService checkoutAttemptService,
+            IWorkContext workContext,
+            IStoreContext storeContext,
+            IShoppingCartService shoppingCartService,
+            IOrderTotalCalculationService orderTotalCalculationService)
+        {
+            _checkoutAttemptService = checkoutAttemptService;
+            _workContext = workContext;
+            _storeContext = storeContext;
+            _shoppingCartService = shoppingCartService;
+            _orderTotalCalculationService = orderTotalCalculationService;
+        }
+
+        // All three express-payment buttons (PayPal wallet, Card, GPay) render
+        // through PayPalCommerce's single SDK call and share the same onClick
+        // hook client-side, so they all map to the same server-side step here —
+        // the distinct event names are still preserved in Clarity/GTM for
+        // funnel breakdown by button type.
+        private static readonly HashSet<string> RecognizedEvents = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "checkout_paypal_express_clicked",
+            "checkout_card_express_clicked",
+            "checkout_gpay_clicked"
+        };
+
+        [HttpPost]
+        [IgnoreAntiforgeryToken] // fired from a PayPal SDK callback context, not a standard form post
+        public async Task<IActionResult> RecordEvent([FromBody] CheckoutTrackingEventModel model)
+        {
+            // Whitelist explicitly — never let arbitrary client input choose the
+            // step, since this endpoint is unauthenticated by necessity.
+            if (string.IsNullOrEmpty(model?.EventName) || !RecognizedEvents.Contains(model.EventName))
+                return BadRequest();
+
+            var step = CheckoutStep.ExpressCheckoutClicked;
+
+            var customer = await _workContext.GetCurrentCustomerAsync();
+            var store = await _storeContext.GetCurrentStoreAsync();
+
+            decimal? cartTotal = null;
+            try
+            {
+                var cart = await _shoppingCartService.GetShoppingCartAsync(customer, ShoppingCartType.ShoppingCart, store.Id);
+                cartTotal = (await _orderTotalCalculationService.GetShoppingCartTotalAsync(cart)).shoppingCartTotal;
+            }
+            catch
+            {
+                // non-critical — don't block on tracking
+            }
+
+            await _checkoutAttemptService.RecordStepAsync(
+                customer.Id, customer.CustomerGuid.ToString(), store.Id, step, cartTotal);
+
+            return Ok();
+        }
+    }
+}
+

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Data/CheckoutAttemptBuilder.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Data/CheckoutAttemptBuilder.cs
@@ -1,0 +1,23 @@
+using FluentMigrator.Builders.Create.Table;
+using Nop.Data.Mapping.Builders;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Domain;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker.Data
+{
+    public class CheckoutAttemptBuilder : NopEntityBuilder<CheckoutAttempt>
+    {
+        public override void MapEntity(CreateTableExpressionBuilder table)
+        {
+            table
+                .WithColumn(nameof(CheckoutAttempt.CustomerId)).AsInt32().Nullable()
+                .WithColumn(nameof(CheckoutAttempt.CustomerGuid)).AsString(36).NotNullable()
+                .WithColumn(nameof(CheckoutAttempt.StoreId)).AsInt32().NotNullable()
+                .WithColumn(nameof(CheckoutAttempt.StartedOnUtc)).AsDateTime2().NotNullable()
+                .WithColumn(nameof(CheckoutAttempt.LastActivityUtc)).AsDateTime2().NotNullable()
+                .WithColumn(nameof(CheckoutAttempt.LastStepReachedId)).AsInt32().NotNullable()
+                .WithColumn(nameof(CheckoutAttempt.OrderId)).AsInt32().Nullable()
+                .WithColumn(nameof(CheckoutAttempt.IsAbandoned)).AsBoolean().NotNullable()
+                .WithColumn(nameof(CheckoutAttempt.CartTotal)).AsDecimal(18, 4).Nullable();
+        }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Domain/CheckoutAttempt.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Domain/CheckoutAttempt.cs
@@ -1,0 +1,35 @@
+using System;
+using Nop.Core;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker.Domain
+{
+    public class CheckoutAttempt : BaseEntity
+    {
+        public int? CustomerId { get; set; }
+        public string CustomerGuid { get; set; } = string.Empty; // covers guest checkout
+        public int StoreId { get; set; }
+        public DateTime StartedOnUtc { get; set; }
+        public DateTime LastActivityUtc { get; set; }
+        public int LastStepReachedId { get; set; } // maps to CheckoutStep enum
+        public int? OrderId { get; set; } // set on successful completion
+        public bool IsAbandoned { get; set; }
+        public decimal? CartTotal { get; set; }
+
+        public CheckoutStep LastStepReached
+        {
+            get => (CheckoutStep)LastStepReachedId;
+            set => LastStepReachedId = (int)value;
+        }
+    }
+
+    public enum CheckoutStep
+    {
+        CartViewed = 10,
+        CheckoutStarted = 20,
+        BillingAddress = 30,
+        ShippingAddress = 40,
+        PaymentMethod = 50,
+        ExpressCheckoutClicked = 55, // PayPal wallet, Card, and GPay — all render via the same SDK call
+        Confirmed = 60
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Infrastructure/CheckoutAttemptFilter.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Infrastructure/CheckoutAttemptFilter.cs
@@ -1,0 +1,104 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Nop.Core;
+using Nop.Core.Domain.Orders;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Domain;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Services;
+using Nop.Services.Orders;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker.Infrastructure
+{
+    public class CheckoutAttemptFilter : IAsyncActionFilter
+    {
+        private readonly ICheckoutAttemptService _checkoutAttemptService;
+        private readonly IWorkContext _workContext;
+        private readonly IStoreContext _storeContext;
+        private readonly IShoppingCartService _shoppingCartService;
+        private readonly IOrderTotalCalculationService _orderTotalCalculationService;
+
+        public CheckoutAttemptFilter(
+            ICheckoutAttemptService checkoutAttemptService,
+            IWorkContext workContext,
+            IStoreContext storeContext,
+            IShoppingCartService shoppingCartService,
+            IOrderTotalCalculationService orderTotalCalculationService)
+        {
+            _checkoutAttemptService = checkoutAttemptService;
+            _workContext = workContext;
+            _storeContext = storeContext;
+            _shoppingCartService = shoppingCartService;
+            _orderTotalCalculationService = orderTotalCalculationService;
+        }
+
+        public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        {
+            var executedContext = await next();
+
+            if (executedContext.Exception != null && !executedContext.ExceptionHandled)
+                return;
+
+            var controllerName = context.RouteData.Values["controller"]?.ToString() ?? string.Empty;
+            var actionName = context.RouteData.Values["action"]?.ToString() ?? string.Empty;
+            var httpMethod = context.HttpContext.Request.Method;
+
+            var step = MapToStep(controllerName, actionName, httpMethod);
+            if (step == null)
+                return;
+
+            var customer = await _workContext.GetCurrentCustomerAsync();
+            var store = await _storeContext.GetCurrentStoreAsync();
+
+            // Skip logging entirely for customers with an empty cart hitting the
+            // cart page — otherwise every casual browse of an empty cart page
+            // creates a row.
+            var cart = await _shoppingCartService.GetShoppingCartAsync(customer, ShoppingCartType.ShoppingCart, store.Id);
+            if (step == CheckoutStep.CartViewed && !cart.Any())
+                return;
+
+            decimal? cartTotal = null;
+            try
+            {
+                cartTotal = (await _orderTotalCalculationService.GetShoppingCartTotalAsync(cart)).shoppingCartTotal;
+            }
+            catch
+            {
+                // Total calculation can legitimately throw mid-checkout (e.g. no
+                // shipping method selected yet) — don't let a tracking failure
+                // break the actual checkout flow.
+            }
+
+            await _checkoutAttemptService.RecordStepAsync(
+                customer.Id,
+                customer.CustomerGuid.ToString(),
+                store.Id,
+                step.Value,
+                cartTotal);
+        }
+
+        // GET-arrival based mapping: tracks how far a customer actually reached
+        // (page load), not just which forms they successfully submitted. See
+        // README for why this was chosen over POST-only tracking.
+        private static CheckoutStep? MapToStep(string controller, string action, string httpMethod)
+        {
+            if (controller == "ShoppingCart" && action == "Cart" && httpMethod == "GET")
+                return CheckoutStep.CartViewed;
+
+            if (controller == "Checkout")
+            {
+                return (action, httpMethod) switch
+                {
+                    ("Index", "GET") => CheckoutStep.CheckoutStarted,
+                    ("BillingAddress", "GET") => CheckoutStep.BillingAddress,
+                    ("ShippingAddress", "GET") => CheckoutStep.ShippingAddress,
+                    ("PaymentMethod", "GET") => CheckoutStep.PaymentMethod,
+                    ("Confirm", "GET") => CheckoutStep.Confirmed,
+                    _ => (CheckoutStep?)null
+                };
+            }
+
+            return null;
+        }
+    }
+}
+

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Migrations/SchemaMigration.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Migrations/SchemaMigration.cs
@@ -1,0 +1,49 @@
+using FluentMigrator;
+using Nop.Data.Extensions;
+using Nop.Data.Migrations;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Domain;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker.Migrations
+{
+    // IMPORTANT: update this timestamp to match when you actually run the
+    // install — do not leave it backdated to when this was drafted.
+    [NopMigration("2026-08-09 00:00:00", "CheckoutAttempt table", MigrationProcessType.Installation)]
+    public class SchemaMigration : Migration
+    {
+        public override void Up()
+        {
+            this.CreateTableIfNotExists<CheckoutAttempt>();
+
+            // Indexes matter here — RecordStepAsync and MarkCompletedAsync both
+            // filter on these columns on every checkout step, so unindexed this
+            // will get slow once the table has any real volume.
+            Create.Index("IX_CheckoutAttempt_CustomerGuid_Store_Open")
+                .OnTable(nameof(CheckoutAttempt))
+                .OnColumn(nameof(CheckoutAttempt.CustomerGuid)).Ascending()
+                .OnColumn(nameof(CheckoutAttempt.StoreId)).Ascending()
+                .OnColumn(nameof(CheckoutAttempt.OrderId)).Ascending()
+                .OnColumn(nameof(CheckoutAttempt.IsAbandoned)).Ascending();
+
+            Create.Index("IX_CheckoutAttempt_CustomerId_Open")
+                .OnTable(nameof(CheckoutAttempt))
+                .OnColumn(nameof(CheckoutAttempt.CustomerId)).Ascending()
+                .OnColumn(nameof(CheckoutAttempt.OrderId)).Ascending()
+                .OnColumn(nameof(CheckoutAttempt.IsAbandoned)).Ascending();
+
+            // Supports FlagAbandonedAsync's scan for stale open attempts
+            Create.Index("IX_CheckoutAttempt_LastActivity_Open")
+                .OnTable(nameof(CheckoutAttempt))
+                .OnColumn(nameof(CheckoutAttempt.LastActivityUtc)).Ascending()
+                .OnColumn(nameof(CheckoutAttempt.OrderId)).Ascending()
+                .OnColumn(nameof(CheckoutAttempt.IsAbandoned)).Ascending();
+        }
+
+        public override void Down()
+        {
+            // Deliberately not dropping the table here — see README.
+            // If you do want uninstall to remove data, uncomment:
+            // Delete.Table(nameof(CheckoutAttempt));
+        }
+    }
+}
+

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Models/CheckoutAttemptModels.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Models/CheckoutAttemptModels.cs
@@ -1,0 +1,31 @@
+using System;
+using Nop.Web.Framework.Models;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker.Models
+{
+    public record CheckoutAttemptSearchModel : BaseSearchModel
+    {
+        public bool AbandonedOnly { get; set; } = true;
+    }
+
+    public record CheckoutAttemptModel : BaseNopEntityModel
+    {
+        public string CustomerEmail { get; set; } = string.Empty;
+        public string CustomerGuid { get; set; } = string.Empty;
+        public string LastStepReached { get; set; } = string.Empty;
+        public DateTime StartedOnUtc { get; set; }
+        public DateTime LastActivityUtc { get; set; }
+        public decimal? CartTotal { get; set; }
+        public bool IsAbandoned { get; set; }
+        public int? OrderId { get; set; }
+    }
+
+    public record CheckoutAttemptListModel : BasePagedListModel<CheckoutAttemptModel>;
+
+    // Payload for the public storefront tracking endpoint (PayPal Express etc.)
+    public record CheckoutTrackingEventModel : BaseNopModel
+    {
+        public string EventName { get; set; } = string.Empty;
+    }
+}
+

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Nop.Plugin.Misc.CheckoutAbandonmentTracker.csproj
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Nop.Plugin.Misc.CheckoutAbandonmentTracker.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Copyright>Derrick Madden</Copyright>
+    <SolutionDir Condition="'$(SolutionDir)' == ''">$(MSBuildProjectDirectory)\..\..\</SolutionDir>
+    <OutputPath>$(SolutionDir)\Presentation\Nop.Web\Plugins\Misc.CheckoutAbandonmentTracker</OutputPath>
+    <OutDir>$(OutputPath)</OutDir>
+    <!--Set this parameter to true to get the dlls copied from the NuGet cache to the output of your project. 
+    You need to set this parameter to true if your plugin has a nuget package 
+    to ensure that the dlls copied from the NuGet cache to the output of your project-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+
+  <ItemGroup>
+    <None Remove="plugin.json" />
+    <None Remove="Views\List.cshtml" />
+    <None Remove="Views\_ViewImports.cshtml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="plugin.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Views\List.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Views\_ViewImports.cshtml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SolutionDir)\Presentation\Nop.Web\Nop.Web.csproj" />
+    <ClearPluginAssemblies Include="$(SolutionDir)\Build\ClearPluginAssemblies.proj" />
+  </ItemGroup>
+
+  <!-- This target execute after "Build" target -->
+  <Target Name="NopTarget" AfterTargets="Build">
+    <!-- Delete unnecessary libraries from plugins path -->
+    <MSBuild Projects="@(ClearPluginAssemblies)" Properties="PluginPath=$(OutDir)" Targets="NopClear" />
+  </Target>
+
+</Project>
+

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/NopStartup.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/NopStartup.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nop.Core.Infrastructure;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Infrastructure;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Services;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker
+{
+    public class NopStartup : INopStartup
+    {
+        public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddScoped<ICheckoutAttemptService, CheckoutAttemptService>();
+            services.AddScoped<CheckoutAttemptFilter>();
+
+            // Global filter, gated by controller/action check inside the filter
+            // itself, so core ShoppingCartController/CheckoutController files
+            // never need to be touched directly.
+            services.Configure<MvcOptions>(options =>
+            {
+                options.Filters.Add<CheckoutAttemptFilter>();
+            });
+        }
+
+        public void Configure(IApplicationBuilder application)
+        {
+        }
+
+        // Runs after core services are registered
+        public int Order => 2000;
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/RouteProvider.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/RouteProvider.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Nop.Web.Framework.Mvc.Routing;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker
+{
+    public class RouteProvider : IRouteProvider
+    {
+        public void RegisterRoutes(IEndpointRouteBuilder endpointRouteBuilder)
+        {
+            endpointRouteBuilder.MapControllerRoute("CheckoutTracking.RecordEvent",
+                "checkout-tracking/record",
+                new { controller = "CheckoutTracking", action = "RecordEvent" });
+        }
+
+        public int Priority => 0;
+    }
+}
+

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Scripts/paypal-onclick-hook.js
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Scripts/paypal-onclick-hook.js
@@ -1,0 +1,56 @@
+// Add inside the existing paypal.Buttons({...}) config in
+// ~/Plugins/Payments.PayPalCommerce/Views/PaymentInfo.cshtml (find it via:
+// grep -rn "paypal.Buttons" src/Plugins/Nop.Plugin.Payments.PayPalCommerce/)
+//
+// IMPORTANT: do not replace the existing callback bodies — the plugin's own
+// onApprove/onError logic handles the actual payment flow. Add the
+// dataLayer.push / fetch calls as the FIRST lines inside each existing
+// callback, keeping everything else intact.
+
+paypal.Buttons({
+    onClick: function (data, actions) {
+        var eventName = 'checkout_paypal_express_clicked';
+        if (data.fundingSource === 'card') eventName = 'checkout_card_express_clicked';
+        if (data.fundingSource === 'googlepay') eventName = 'checkout_gpay_clicked';
+
+        if (typeof dataLayer !== 'undefined') {
+            dataLayer.push({ event: eventName });
+        }
+
+        fetch('/checkout-tracking/record', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin', // carries the session cookie so
+                                         // GetCurrentCustomerAsync resolves correctly
+            body: JSON.stringify({ eventName: eventName }),
+            keepalive: true // survives the page navigating away right after click
+        }).catch(function () { /* non-critical, don't block checkout on tracking */ });
+
+        // ...existing onClick logic continues here, unchanged
+    },
+    onApprove: function (data, actions) {
+        if (typeof dataLayer !== 'undefined') {
+            dataLayer.push({ event: 'checkout_paypal_express_approved' });
+        }
+        // Deliberately no server-side call here — OrderPlacedEvent /
+        // OrderPlacedConsumer already reconciles this attempt as completed
+        // once the order is actually placed. A redundant call here risks
+        // double-counting.
+
+        // ...existing onApprove logic continues here, unchanged
+    },
+    onCancel: function (data) {
+        if (typeof dataLayer !== 'undefined') {
+            dataLayer.push({ event: 'checkout_paypal_express_cancelled' });
+        }
+        // No server call — the attempt already correctly sits "open" at
+        // ExpressCheckoutClicked; that's the honest state until it either
+        // completes or times out via FlagAbandonedAsync.
+    },
+    onError: function (err) {
+        if (typeof dataLayer !== 'undefined') {
+            dataLayer.push({ event: 'checkout_paypal_express_error' });
+        }
+    }
+    // ...rest of existing config (createOrder, style, etc.)
+}).render('#paypal-button-container');

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Scripts/theme-checkout-tracking.js
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Scripts/theme-checkout-tracking.js
@@ -1,0 +1,13 @@
+// Add this directly to your theme (NOT via GTM) on cart/checkout pages.
+// Uses visibilitychange rather than beforeunload, which is more reliably
+// supported for "did the user leave" tracking across browsers.
+(function () {
+  var cartHasItems = document.querySelector('.cart-item-row') || document.querySelector('.checkout-data');
+  if (!cartHasItems) return;
+
+  document.addEventListener('visibilitychange', function () {
+    if (document.visibilityState === 'hidden' && typeof clarity === 'function') {
+      clarity('event', 'checkout_left_page');
+    }
+  });
+})();

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Services/AbandonedCheckoutTask.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Services/AbandonedCheckoutTask.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+using Nop.Services.ScheduleTasks;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker.Services
+{
+    public class AbandonedCheckoutTask : IScheduleTask
+    {
+        private readonly ICheckoutAttemptService _checkoutAttemptService;
+
+        public AbandonedCheckoutTask(ICheckoutAttemptService checkoutAttemptService)
+        {
+            _checkoutAttemptService = checkoutAttemptService;
+        }
+
+        public async Task ExecuteAsync()
+        {
+            var cutoff = DateTime.UtcNow.AddMinutes(-45); // tune this threshold
+            await _checkoutAttemptService.FlagAbandonedAsync(cutoff);
+        }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Services/CheckoutAttemptService.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Services/CheckoutAttemptService.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Nop.Core;
+using Nop.Data;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Domain;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker.Services
+{
+    public class CheckoutAttemptService : ICheckoutAttemptService
+    {
+        private readonly IRepository<CheckoutAttempt> _checkoutAttemptRepository;
+
+        public CheckoutAttemptService(IRepository<CheckoutAttempt> checkoutAttemptRepository)
+        {
+            _checkoutAttemptRepository = checkoutAttemptRepository;
+        }
+
+        public async Task<CheckoutAttempt> RecordStepAsync(int customerId, string customerGuid, int storeId, CheckoutStep step, decimal? cartTotal = null)
+        {
+            // "Open" = not yet completed (OrderId null) and not yet flagged abandoned.
+            // Guests are tracked purely by CustomerGuid since CustomerId is shared
+            // across all anonymous customers in nopCommerce.
+            var query = _checkoutAttemptRepository.Table
+                .Where(a => a.CustomerGuid == customerGuid
+                         && a.StoreId == storeId
+                         && a.OrderId == null
+                         && !a.IsAbandoned);
+
+            var attempt = await query.OrderByDescending(a => a.LastActivityUtc).FirstOrDefaultAsync();
+
+            var nowUtc = DateTime.UtcNow;
+
+            if (attempt == null)
+            {
+                attempt = new CheckoutAttempt
+                {
+                    CustomerId = customerId,
+                    CustomerGuid = customerGuid,
+                    StoreId = storeId,
+                    StartedOnUtc = nowUtc,
+                    LastActivityUtc = nowUtc,
+                    LastStepReached = step,
+                    CartTotal = cartTotal,
+                    IsAbandoned = false
+                };
+                await _checkoutAttemptRepository.InsertAsync(attempt);
+            }
+            else
+            {
+                // Only move the step forward — a customer navigating back to an
+                // earlier step (e.g. "edit shipping address") shouldn't regress
+                // the recorded progress.
+                if (step > attempt.LastStepReached)
+                    attempt.LastStepReached = step;
+
+                attempt.LastActivityUtc = nowUtc;
+                if (cartTotal.HasValue)
+                    attempt.CartTotal = cartTotal;
+
+                await _checkoutAttemptRepository.UpdateAsync(attempt);
+            }
+
+            return attempt;
+        }
+
+        public async Task MarkCompletedAsync(int customerId, int orderId)
+        {
+            // Match on CustomerId here rather than CustomerGuid, since by the time
+            // OrderPlacedEvent fires the customer may have been converted from
+            // guest to registered — CustomerId is reliably set on the placed
+            // order itself.
+            var attempt = await _checkoutAttemptRepository.Table
+                .Where(a => a.CustomerId == customerId && a.OrderId == null && !a.IsAbandoned)
+                .OrderByDescending(a => a.LastActivityUtc)
+                .FirstOrDefaultAsync();
+
+            if (attempt == null)
+                return; // nothing open to reconcile — fine, not every order needs a matching attempt
+
+            attempt.OrderId = orderId;
+            attempt.LastActivityUtc = DateTime.UtcNow;
+            await _checkoutAttemptRepository.UpdateAsync(attempt);
+        }
+
+        public async Task<int> FlagAbandonedAsync(DateTime cutoffUtc)
+        {
+            var staleAttempts = await _checkoutAttemptRepository.Table
+                .Where(a => a.OrderId == null && !a.IsAbandoned && a.LastActivityUtc < cutoffUtc)
+                .ToListAsync();
+
+            foreach (var attempt in staleAttempts)
+                attempt.IsAbandoned = true;
+
+            if (staleAttempts.Count > 0)
+                await _checkoutAttemptRepository.UpdateAsync(staleAttempts);
+
+            return staleAttempts.Count;
+        }
+
+        public async Task<IPagedList<CheckoutAttempt>> GetAbandonedAttemptsAsync(int storeId, int pageIndex = 0, int pageSize = 50)
+        {
+            var query = _checkoutAttemptRepository.Table
+                .Where(a => a.StoreId == storeId && a.IsAbandoned)
+                .OrderByDescending(a => a.LastActivityUtc);
+
+            return await query.ToPagedListAsync(pageIndex, pageSize);
+        }
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Services/ICheckoutAttemptService.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Services/ICheckoutAttemptService.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading.Tasks;
+using Nop.Core;
+using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Domain;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker.Services
+{
+    public interface ICheckoutAttemptService
+    {
+        Task<CheckoutAttempt> RecordStepAsync(int customerId, string customerGuid, int storeId, CheckoutStep step, decimal? cartTotal = null);
+        Task MarkCompletedAsync(int customerId, int orderId);
+        Task<int> FlagAbandonedAsync(DateTime cutoffUtc);
+        Task<IPagedList<CheckoutAttempt>> GetAbandonedAttemptsAsync(int storeId, int pageIndex = 0, int pageSize = 50);
+    }
+}

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Services/OrderPlacedConsumer.cs
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Services/OrderPlacedConsumer.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Nop.Core.Domain.Orders;
+using Nop.Services.Events;
+
+namespace Nop.Plugin.Misc.CheckoutAbandonmentTracker.Services
+{
+    public class OrderPlacedConsumer : IConsumer<OrderPlacedEvent>
+    {
+        private readonly ICheckoutAttemptService _checkoutAttemptService;
+
+        public OrderPlacedConsumer(ICheckoutAttemptService checkoutAttemptService)
+        {
+            _checkoutAttemptService = checkoutAttemptService;
+        }
+
+        public async Task HandleEventAsync(OrderPlacedEvent eventMessage)
+        {
+            var order = eventMessage.Order;
+            await _checkoutAttemptService.MarkCompletedAsync(order.CustomerId, order.Id);
+        }
+    }
+}
+

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Views/List.cshtml
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Views/List.cshtml
@@ -1,0 +1,38 @@
+@model CheckoutAttemptSearchModel
+@using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Models
+@{
+    Layout = "_AdminLayout";
+    ViewBag.PageTitle = "Abandoned Checkouts";
+}
+
+@* NOTE: this view assumes nopCommerce's standard admin Table/DataTablesModel
+   partial (as used throughout core admin grids). Adjust ColumnProperty /
+   DataUrl usage to match whatever version of the admin grid helpers your
+   4.90 fork uses if it's been customized. *@
+
+<form asp-controller="CheckoutAbandonmentTracker" asp-action="List" method="post">
+    <div class="content-header clearfix">
+        <h1 class="float-left">Abandoned Checkouts</h1>
+    </div>
+    <div class="content">
+        <div class="card card-default">
+            <div class="card-body">
+                @await Html.PartialAsync("Table", new DataTablesModel
+                {
+                    Name = "checkout-attempts-grid",
+                    UrlRead = new DataUrl("ListData", "CheckoutAbandonmentTracker", null),
+                    Length = 50,
+                    LengthMenu = "50, 100, 250",
+                    ColumnCollection = new List<ColumnProperty>
+                    {
+                        new ColumnProperty(nameof(CheckoutAttemptModel.CustomerEmail)) { Title = "Customer" },
+                        new ColumnProperty(nameof(CheckoutAttemptModel.LastStepReached)) { Title = "Last Step" },
+                        new ColumnProperty(nameof(CheckoutAttemptModel.CartTotal)) { Title = "Cart Total" },
+                        new ColumnProperty(nameof(CheckoutAttemptModel.StartedOnUtc)) { Title = "Started", Render = new RenderDate() },
+                        new ColumnProperty(nameof(CheckoutAttemptModel.LastActivityUtc)) { Title = "Last Activity", Render = new RenderDate() }
+                    }
+                })
+            </div>
+        </div>
+    </div>
+</form>

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Views/_ViewImports.cshtml
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/Views/_ViewImports.cshtml
@@ -1,0 +1,17 @@
+@inherits Nop.Web.Framework.Mvc.Razor.NopRazorPage<TModel>
+
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, Nop.Web.Framework
+
+@using System.Text.Encodings.Web
+@using Microsoft.AspNetCore.Mvc.ViewFeatures
+@using Microsoft.AspNetCore.Routing
+@using Nop.Core
+@using Nop.Core.Infrastructure
+@using Nop.Plugin.Misc.CheckoutAbandonmentTracker
+@using Nop.Plugin.Misc.CheckoutAbandonmentTracker.Models
+@using Nop.Services.Common
+@using Nop.Web.Framework
+@using Nop.Web.Framework.Models
+@using Nop.Web.Framework.Models.DataTables
+@using Nop.Web.Framework.TagHelpers.Admin

--- a/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/plugin.json
+++ b/src/Plugins/Nop.Plugin.Misc.CheckoutAbandonmentTracker/plugin.json
@@ -1,0 +1,11 @@
+{
+  "Group": "Misc",
+  "FriendlyName": "Checkout Abandonment Tracker",
+  "SystemName": "Misc.CheckoutAbandonmentTracker",
+  "Version": "1.00",
+  "SupportedVersions": [ "5.00" ],
+  "Author": "Derrick",
+  "DisplayOrder": 1,
+  "FileName": "Nop.Plugin.Misc.CheckoutAbandonmentTracker.dll",
+  "Description": "Server-side checkout funnel and abandonment logging"
+}


### PR DESCRIPTION
Add Checkout Abandonment Tracker plugin

Introduced a new plugin for server-side tracking of checkout funnel progress and abandonment events. Added database entity and migrations for persisting checkout attempts, with service layer for managing and reporting abandoned checkouts. Registered a scheduled task to flag stale attempts and an event consumer to reconcile orders. Integrated tracking via MVC filter, public and admin controllers, and route provider. Added admin UI for listing abandoned checkouts. Included JavaScript for express checkout and page exit tracking. Plugin is non-intrusive and preserves data on uninstall.