### PR TITLE
Remove ReviewRewardRequirementRule DI registration

### DIFF
--- a/src/Plugins/Nop.Plugin.Misc.ReviewReward/NopStartup.cs
+++ b/src/Plugins/Nop.Plugin.Misc.ReviewReward/NopStartup.cs
@@ -5,10 +5,8 @@ using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Messages;
 using Nop.Core.Events;
 using Nop.Core.Infrastructure;
-using Nop.Plugin.Misc.ReviewReward.Discounts;
 using Nop.Plugin.Misc.ReviewReward.Infrastructure;
 using Nop.Plugin.Misc.ReviewReward.Services;
-using Nop.Services.Discounts;
 using Nop.Services.Events;
 using Nop.Web.Framework.Events;
 
@@ -20,7 +18,6 @@ namespace Nop.Plugin.Misc.ReviewReward
         {
             services.AddScoped<IReviewRewardService, ReviewRewardService>();
             services.AddScoped<IReviewRewardMessageService, ReviewRewardMessageService>();
-            services.AddScoped<IDiscountRequirementRule, ReviewRewardRequirementRule>();
             services.AddScoped<IConsumer<EntityInsertedEvent<ProductReview>>, ProductReviewEventConsumer>();
             services.AddScoped<IConsumer<ProductReviewApprovedEvent>, ProductReviewEventConsumer>();
             services.AddScoped<IConsumer<AdditionalTokensAddedEvent>, ReviewRewardMessageTokenEventConsumer>();


### PR DESCRIPTION
Remove ReviewRewardRequirementRule DI registration

The ReviewRewardRequirementRule is no longer registered as an
IDiscountRequirementRule in the dependency injection container.
This removes the custom discount requirement rule for review
rewards from being available for dependency injection.
No other service registrations were modified.