### PR TITLE
Hide chatbot on checkout; improve mobile checkout UX

### DIFF
--- a/src/Plugins/Nop.Plugin.Widgets.AiChatbot/Components/ChatWidgetViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.AiChatbot/Components/ChatWidgetViewComponent.cs
@@ -20,6 +20,10 @@ public class ChatWidgetViewComponent : NopViewComponent
         if (!_settings.Enabled)
             return Content(string.Empty);
 
+        var controller = ViewContext.RouteData.Values["controller"]?.ToString();
+        if (string.Equals(controller, "Checkout", StringComparison.OrdinalIgnoreCase))
+            return Content(string.Empty);
+
         return View("~/Plugins/Widgets.AiChatbot/Views/ChatWidget.cshtml", _settings);
     }
 }

--- a/src/Plugins/Nop.Plugin.Widgets.AiChatbot/Views/ChatWidget.cshtml
+++ b/src/Plugins/Nop.Plugin.Widgets.AiChatbot/Views/ChatWidget.cshtml
@@ -15,6 +15,13 @@
         z-index: 999998 !important;
     }
 
+    /* Hide chatbot on all checkout pages */
+    html.html-checkout-page #ai-chat-bubble,
+    .html-checkout-page #ai-chat-bubble,
+    .checkout-page #ai-chat-bubble {
+        display: none !important;
+    }
+
     #ai-chat-bubble {
         position: fixed;
         bottom: 24px;

--- a/src/Presentation/Nop.Web/Themes/TheSolidInspired/Content/css/custom_v2.css
+++ b/src/Presentation/Nop.Web/Themes/TheSolidInspired/Content/css/custom_v2.css
@@ -5599,3 +5599,51 @@ body {
     display: flex;
     justify-content: center;
 }
+
+/* --- CHECKOUT MOBILE & CONVERSION ENHANCEMENTS --- */
+/* Completely hide floating chatbot on all checkout pages */
+html.html-checkout-page #ai-chat-bubble,
+.html-checkout-page #ai-chat-bubble,
+.checkout-page #ai-chat-bubble,
+.order-confirm-page #ai-chat-bubble {
+  display: none !important;
+}
+
+/* Ensure adequate breathing room at the bottom of checkout */
+.html-checkout-page .checkout-page {
+  padding-bottom: 70px;
+}
+
+/* On mobile, ensure checkout footer buttons are full width and easy to tap */
+@media (max-width: 768px) {
+  .checkout-footer-modern {
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: stretch !important;
+    align-items: stretch !important;
+    width: 100% !important;
+    margin-top: 30px !important;
+    padding-top: 25px !important;
+    gap: 15px !important;
+  }
+
+  .confirm-order-btn-modern,
+  .checkout-footer-modern .btn-primary,
+  .checkout-footer-modern .next-step-btn {
+    width: 100% !important;
+    min-width: 0 !important;
+    display: flex !important;
+    justify-content: center !important;
+    align-items: center !important;
+    text-align: center !important;
+    padding: 18px 20px !important;
+    font-size: 1.15rem !important;
+    box-sizing: border-box !important;
+  }
+
+  .terms-of-service-modern {
+    width: 100%;
+    margin-bottom: 15px;
+  }
+}
+

--- a/src/Presentation/Nop.Web/Themes/TheSolidInspired/Views/Checkout/Confirm.cshtml
+++ b/src/Presentation/Nop.Web/Themes/TheSolidInspired/Views/Checkout/Confirm.cshtml
@@ -71,9 +71,30 @@
 
                     <script asp-location="Footer">
                         $(function() {
+                            $('#termsofservice').on('change', function () {
+                                if ($(this).is(':checked')) {
+                                    $(this).closest('.terms-of-service-modern').css({
+                                        'border': '',
+                                        'padding': '',
+                                        'background-color': ''
+                                    });
+                                }
+                            });
+
                             $('#confirm-order-form').on('submit', function () {
                                 var button = $(this).find('.confirm-order-btn-modern');
                                 if ($('#termsofservice').length > 0 && !$('#termsofservice').is(':checked')) {
+                                    var termsBox = $('#termsofservice').closest('.terms-of-service-modern');
+                                    termsBox.css({
+                                        'border': '2px solid #ef4444',
+                                        'padding': '12px 16px',
+                                        'border-radius': '8px',
+                                        'background-color': '#fef2f2',
+                                        'transition': 'all 0.3s ease'
+                                    });
+                                    $('html, body').animate({
+                                        scrollTop: termsBox.offset().top - 80
+                                    }, 300);
                                     alert('@T("Checkout.TermsOfService.PleaseAccept")');
                                     return false;
                                 }


### PR DESCRIPTION
Hide chatbot on checkout; improve mobile checkout UX

ChatWidgetViewComponent now hides the chatbot on checkout pages. Added CSS to hide the chat bubble during checkout and order confirmation. Enhanced mobile checkout with full-width footer buttons and better padding. Added JS to highlight the terms checkbox if unchecked on order submit.